### PR TITLE
Clean star imports

### DIFF
--- a/git_sim/git_sim.py
+++ b/git_sim/git_sim.py
@@ -1,4 +1,4 @@
-from manim import BLACK, WHITE, MovingCameraScene
+import manim as m
 
 from git_sim.git_sim_add import GitSimAdd
 from git_sim.git_sim_branch import GitSimBranch
@@ -15,15 +15,15 @@ from git_sim.git_sim_status import GitSimStatus
 from git_sim.git_sim_tag import GitSimTag
 
 
-class GitSim(MovingCameraScene):
+class GitSim(m.MovingCameraScene):
     def __init__(self, args):
         super().__init__()
         self.args = args
 
         if ( self.args.light_mode ):
-            self.fontColor = BLACK
+            self.fontColor = m.BLACK
         else:
-            self.fontColor = WHITE
+            self.fontColor = m.WHITE
 
     def construct(self):
         if self.args.subcommand == 'log':

--- a/git_sim/git_sim.py
+++ b/git_sim/git_sim.py
@@ -1,19 +1,19 @@
-from manim import *
-import git, sys, numpy
+from manim import BLACK, WHITE, MovingCameraScene
 
-from git_sim.git_sim_log import *
-from git_sim.git_sim_status import *
-from git_sim.git_sim_add import *
-from git_sim.git_sim_restore import *
-from git_sim.git_sim_commit import *
-from git_sim.git_sim_stash import *
-from git_sim.git_sim_branch import *
-from git_sim.git_sim_tag import *
-from git_sim.git_sim_reset import *
-from git_sim.git_sim_revert import *
-from git_sim.git_sim_merge import *
-from git_sim.git_sim_rebase import *
-from git_sim.git_sim_cherrypick import *
+from git_sim.git_sim_add import GitSimAdd
+from git_sim.git_sim_branch import GitSimBranch
+from git_sim.git_sim_cherrypick import GitSimCherryPick
+from git_sim.git_sim_commit import GitSimCommit
+from git_sim.git_sim_log import GitSimLog
+from git_sim.git_sim_merge import GitSimMerge
+from git_sim.git_sim_rebase import GitSimRebase
+from git_sim.git_sim_reset import GitSimReset
+from git_sim.git_sim_restore import GitSimRestore
+from git_sim.git_sim_revert import GitSimRevert
+from git_sim.git_sim_stash import GitSimStash
+from git_sim.git_sim_status import GitSimStatus
+from git_sim.git_sim_tag import GitSimTag
+
 
 class GitSim(MovingCameraScene):
     def __init__(self, args):

--- a/git_sim/git_sim_add.py
+++ b/git_sim/git_sim_add.py
@@ -1,6 +1,9 @@
-from manim import *
+import sys
+
+import manim as m
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimAdd(GitSimBaseCommand):
     def __init__(self, scene):
@@ -56,4 +59,4 @@ class GitSimAdd(GitSimBaseCommand):
                 for name in self.scene.args.name:
                     if name == z:
                         thirdColumnFileNames.add(z)
-                        firstColumnArrowMap[z] = Arrow(stroke_width=3, color=self.scene.fontColor)
+                        firstColumnArrowMap[z] = m.Arrow(stroke_width=3, color=self.scene.fontColor)

--- a/git_sim/git_sim_base_command.py
+++ b/git_sim/git_sim_base_command.py
@@ -1,5 +1,10 @@
-from manim import *
-import git, sys, numpy, platform
+import platform
+import sys
+
+import git
+import manim as m
+import numpy
+
 
 class GitSimBaseCommand():
 
@@ -10,8 +15,8 @@ class GitSimBaseCommand():
         self.drawnCommits = {}
         self.drawnRefs = {}
         self.commits = []
-        self.zoomOuts = 0 
-        self.toFadeOut = Group()
+        self.zoomOuts = 0
+        self.toFadeOut = m.Group()
         self.trimmed = False
         self.prevRef = None
         self.topref = None
@@ -25,7 +30,7 @@ class GitSimBaseCommand():
         self.zone_title_offset = 2.6 if platform.system() == "Windows" else 2.6
         self.allow_no_commits = False
 
-        self.logo = ImageMobject(self.scene.args.logo)
+        self.logo = m.ImageMobject(self.scene.args.logo)
         self.logo.width = 3
 
     def init_repo(self):
@@ -92,38 +97,38 @@ class GitSimBaseCommand():
         if ( self.scene.args.animate and self.scene.args.show_intro ):
             self.scene.add(self.logo)
 
-            initialCommitText = Text(self.scene.args.title, font="Monospace", font_size=36, color=self.scene.fontColor).to_edge(UP, buff=1)
+            initialCommitText = m.Text(self.scene.args.title, font="Monospace", font_size=36, color=self.scene.fontColor).to_edge(m.UP, buff=1)
             self.scene.add(initialCommitText)
             self.scene.wait(2)
-            self.scene.play(FadeOut(initialCommitText))
-            self.scene.play(self.logo.animate.scale(0.25).to_edge(UP, buff=0).to_edge(RIGHT, buff=0))
-    
+            self.scene.play(m.FadeOut(initialCommitText))
+            self.scene.play(self.logo.animate.scale(0.25).to_edge(m.UP, buff=0).to_edge(m.RIGHT, buff=0))
+
             self.scene.camera.frame.save_state()
-            self.scene.play(FadeOut(self.logo))
+            self.scene.play(m.FadeOut(self.logo))
 
         else:
-            self.logo.scale(0.25).to_edge(UP, buff=0).to_edge(RIGHT, buff=0)
-            self.scene.camera.frame.save_state()        
+            self.logo.scale(0.25).to_edge(m.UP, buff=0).to_edge(m.RIGHT, buff=0)
+            self.scene.camera.frame.save_state()
 
     def show_outro(self):
         if ( self.scene.args.animate and self.scene.args.show_outro ):
 
-            self.scene.play(Restore(self.scene.camera.frame))
+            self.scene.play(m.Restore(self.scene.camera.frame))
 
             self.scene.play(self.logo.animate.scale(4).set_x(0).set_y(0))
 
-            outroTopText = Text(self.scene.args.outro_top_text, font="Monospace", font_size=36, color=self.scene.fontColor).to_edge(UP, buff=1)
-            self.scene.play(AddTextLetterByLetter(outroTopText))
+            outroTopText = m.Text(self.scene.args.outro_top_text, font="Monospace", font_size=36, color=self.scene.fontColor).to_edge(m.UP, buff=1)
+            self.scene.play(m.AddTextLetterByLetter(outroTopText))
 
-            outroBottomText = Text(self.scene.args.outro_bottom_text, font="Monospace", font_size=36, color=self.scene.fontColor).to_edge(DOWN, buff=1)
-            self.scene.play(AddTextLetterByLetter(outroBottomText))
+            outroBottomText = m.Text(self.scene.args.outro_bottom_text, font="Monospace", font_size=36, color=self.scene.fontColor).to_edge(m.DOWN, buff=1)
+            self.scene.play(m.AddTextLetterByLetter(outroBottomText))
 
             self.scene.wait(3)
 
     def fadeout(self):
         if self.scene.args.animate:
             self.scene.wait(3)
-            self.scene.play(FadeOut(self.toFadeOut), run_time=1/self.scene.args.speed)
+            self.scene.play(m.FadeOut(self.toFadeOut), run_time=1/self.scene.args.speed)
         else:
             self.scene.wait(0.1)
 
@@ -135,43 +140,43 @@ class GitSimBaseCommand():
 
     def draw_commit(self, commit, prevCircle, shift=numpy.array([0., 0., 0.])):
         if commit == "dark":
-            commitFill = WHITE if self.scene.args.light_mode else BLACK
+            commitFill = m.WHITE if self.scene.args.light_mode else m.BLACK
         elif ( len(commit.parents) <= 1 ):
-            commitFill = RED 
+            commitFill = m.RED
         else:
-            commitFill = GRAY
+            commitFill = m.GRAY
 
-        circle = Circle(stroke_color=commitFill, fill_color=commitFill, fill_opacity=0.25)
-        circle.height = 1 
+        circle = m.Circle(stroke_color=commitFill, fill_color=commitFill, fill_opacity=0.25)
+        circle.height = 1
 
         if shift.any():
             circle.shift(shift)
 
         if prevCircle:
-            circle.next_to(prevCircle, RIGHT if self.scene.args.reverse else LEFT, buff=1.5)
+            circle.next_to(prevCircle,m.RIGHT if self.scene.args.reverse else m.LEFT, buff=1.5)
 
-        start = prevCircle.get_center() if prevCircle else ( LEFT if self.scene.args.reverse else RIGHT )
+        start = prevCircle.get_center() if prevCircle else ( m.LEFT if self.scene.args.reverse else m.RIGHT )
         end = circle.get_center()
 
         if commit == "dark":
-            arrow = Arrow(start, end, color=WHITE if self.scene.args.light_mode else BLACK)
+            arrow = m.Arrow(start, end, color=m.WHITE if self.scene.args.light_mode else m.BLACK)
         elif commit.hexsha in self.drawnCommits:
             end = self.drawnCommits[commit.hexsha].get_center()
-            arrow = Arrow(start, end, color=self.scene.fontColor)
+            arrow = m.Arrow(start, end, color=self.scene.fontColor)
             self.stop = True
         else:
-            arrow = Arrow(start, end, color=self.scene.fontColor)
+            arrow = m.Arrow(start, end, color=self.scene.fontColor)
 
         length = numpy.linalg.norm(start-end) - ( 1.5 if start[1] == end[1] else 3  )
         arrow.set_length(length)
 
         commitId, commitMessage, commit, hide_refs = self.build_commit_id_and_message(commit)
-        commitId.next_to(circle, UP)
+        commitId.next_to(circle, m.UP)
 
-        message = Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, DOWN)
+        message = m.Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, m.DOWN)
 
         if self.scene.args.animate and commit != "dark" and not self.stop:
-            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), Create(circle), AddTextLetterByLetter(commitId), AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
+            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), m.Create(circle), m.AddTextLetterByLetter(commitId), m.AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
         elif not self.stop:
             self.scene.add(circle, commitId, message)
         else:
@@ -188,25 +193,25 @@ class GitSimBaseCommand():
     def build_commit_id_and_message(self, commit):
         hide_refs = False
         if commit == "dark":
-            commitId = Text("", font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text("", font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = ""
         else:
-            commitId = Text(commit.hexsha[0:6], font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text(commit.hexsha[0:6], font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = commit.message.split("\n")[0][:40].replace("\n", " ")
         return commitId, commitMessage, commit, hide_refs
 
     def draw_head(self, commit, commitId):
         if ( commit.hexsha == self.repo.head.commit.hexsha ):
-            headbox = Rectangle(color=BLUE, fill_color=BLUE, fill_opacity=0.25)
-            headbox.width = 1 
-            headbox.height = 0.4 
-            headbox.next_to(commitId, UP) 
-            headText = Text("HEAD", font="Monospace", font_size=20, color=self.scene.fontColor).move_to(headbox.get_center())
+            headbox = m.Rectangle(color=m.BLUE, fill_color=m.BLUE, fill_opacity=0.25)
+            headbox.width = 1
+            headbox.height = 0.4
+            headbox.next_to(commitId, m.UP)
+            headText = m.Text("HEAD", font="Monospace", font_size=20, color=self.scene.fontColor).move_to(headbox.get_center())
 
-            head = VGroup(headbox, headText)
+            head = m.VGroup(headbox, headText)
 
             if self.scene.args.animate:
-                self.scene.play(Create(head), run_time=1/self.scene.args.speed)
+                self.scene.play(m.Create(head), run_time=1/self.scene.args.speed)
             else:
                 self.scene.add(head)
 
@@ -218,7 +223,7 @@ class GitSimBaseCommand():
                 self.topref = self.prevRef
 
     def draw_branch(self, commit):
-        x = 0 
+        x = 0
         branches = [branch.name for branch in self.repo.heads]
         for selected_branch in self.selected_branches:
             branches.insert(0, branches.pop(branches.index(selected_branch)))
@@ -226,18 +231,18 @@ class GitSimBaseCommand():
         for branch in branches:
 
             if ( commit.hexsha == self.repo.heads[branch].commit.hexsha ):
-                branchText = Text(branch, font="Monospace", font_size=20, color=self.scene.fontColor)
-                branchRec = Rectangle(color=GREEN, fill_color=GREEN, fill_opacity=0.25, height=0.4, width=branchText.width+0.25)
+                branchText = m.Text(branch, font="Monospace", font_size=20, color=self.scene.fontColor)
+                branchRec = m.Rectangle(color=m.GREEN, fill_color=m.GREEN, fill_opacity=0.25, height=0.4, width=branchText.width+0.25)
 
-                branchRec.next_to(self.prevRef, UP) 
+                branchRec.next_to(self.prevRef, m.UP)
                 branchText.move_to(branchRec.get_center())
 
-                fullbranch = VGroup(branchRec, branchText)
+                fullbranch = m.VGroup(branchRec, branchText)
 
                 self.prevRef = fullbranch
 
                 if self.scene.args.animate:
-                    self.scene.play(Create(fullbranch), run_time=1/self.scene.args.speed)
+                    self.scene.play(m.Create(fullbranch), run_time=1/self.scene.args.speed)
                 else:
                     self.scene.add(fullbranch)
 
@@ -253,25 +258,25 @@ class GitSimBaseCommand():
 
 
     def draw_tag(self, commit):
-        x = 0 
+        x = 0
 
         if self.hide_first_tag and self.i == 0:
             return
-        
+
         for tag in self.repo.tags:
 
             try:
                 if ( commit.hexsha == tag.commit.hexsha ):
-                    tagText = Text(tag.name, font="Monospace", font_size=20, color=self.scene.fontColor)
-                    tagRec = Rectangle(color=YELLOW, fill_color=YELLOW, fill_opacity=0.25, height=0.4, width=tagText.width+0.25)
+                    tagText = m.Text(tag.name, font="Monospace", font_size=20, color=self.scene.fontColor)
+                    tagRec = m.Rectangle(color=m.YELLOW, fill_color=m.YELLOW, fill_opacity=0.25, height=0.4, width=tagText.width+0.25)
 
-                    tagRec.next_to(self.prevRef, UP) 
+                    tagRec.next_to(self.prevRef, m.UP)
                     tagText.move_to(tagRec.get_center())
 
                     self.prevRef = tagRec
 
                     if self.scene.args.animate:
-                        self.scene.play(Create(tagRec), Create(tagText), run_time=1/self.scene.args.speed)
+                        self.scene.play(m.Create(tagRec), m.Create(tagText), run_time=1/self.scene.args.speed)
                     else:
                         self.scene.add(tagRec, tagText)
 
@@ -287,9 +292,9 @@ class GitSimBaseCommand():
                 pass
 
     def draw_arrow(self, prevCircle, arrow):
-        if prevCircle: 
+        if prevCircle:
             if self.scene.args.animate:
-                self.scene.play(Create(arrow), run_time=1/self.scene.args.speed)
+                self.scene.play(m.Create(arrow), run_time=1/self.scene.args.speed)
             else:
                 self.scene.add(arrow)
 
@@ -319,30 +324,30 @@ class GitSimBaseCommand():
 
         try:
             if self.scene.args.animate:
-                self.scene.play(self.toFadeOut.animate.align_to(self.scene.camera.frame, UP).shift(DOWN*0.75))
+                self.scene.play(self.toFadeOut.animate.align_to(self.scene.camera.frame, m.UP).shift(m.DOWN*0.75))
             else:
-                self.toFadeOut.align_to(self.scene.camera.frame, UP).shift(DOWN*0.75)
+                self.toFadeOut.align_to(self.scene.camera.frame, m.UP).shift(m.DOWN*0.75)
         except ValueError:
             pass
 
     def setup_and_draw_zones(self, first_column_name="Untracked files", second_column_name="Working directory modifications", third_column_name="Staging area", reverse=False):
-        horizontal = Line((self.scene.camera.frame.get_left()[0], self.scene.camera.frame.get_center()[1], 0), (self.scene.camera.frame.get_right()[0], self.scene.camera.frame.get_center()[1], 0), color=self.scene.fontColor).shift(UP*2.5)
-        horizontal2 = Line((self.scene.camera.frame.get_left()[0], self.scene.camera.frame.get_center()[1], 0), (self.scene.camera.frame.get_right()[0], self.scene.camera.frame.get_center()[1], 0), color=self.scene.fontColor).shift(UP*1.5)
-        vert1 = DashedLine((self.scene.camera.frame.get_left()[0], self.scene.camera.frame.get_bottom()[1], 0), (self.scene.camera.frame.get_left()[0], horizontal.get_start()[1], 0), dash_length=0.2, color=self.scene.fontColor).shift(RIGHT*6.5)
-        vert2 = DashedLine((self.scene.camera.frame.get_right()[0], self.scene.camera.frame.get_bottom()[1], 0), (self.scene.camera.frame.get_right()[0], horizontal.get_start()[1], 0), dash_length=0.2, color=self.scene.fontColor).shift(LEFT*6.5)
+        horizontal = m.Line((self.scene.camera.frame.get_left()[0], self.scene.camera.frame.get_center()[1], 0), (self.scene.camera.frame.get_right()[0], self.scene.camera.frame.get_center()[1], 0), color=self.scene.fontColor).shift(m.UP*2.5)
+        horizontal2 = m.Line((self.scene.camera.frame.get_left()[0], self.scene.camera.frame.get_center()[1], 0), (self.scene.camera.frame.get_right()[0], self.scene.camera.frame.get_center()[1], 0), color=self.scene.fontColor).shift(m.UP*1.5)
+        vert1 = m.DashedLine((self.scene.camera.frame.get_left()[0], self.scene.camera.frame.get_bottom()[1], 0), (self.scene.camera.frame.get_left()[0], horizontal.get_start()[1], 0), dash_length=0.2, color=self.scene.fontColor).shift(m.RIGHT*6.5)
+        vert2 = m.DashedLine((self.scene.camera.frame.get_right()[0], self.scene.camera.frame.get_bottom()[1], 0), (self.scene.camera.frame.get_right()[0], horizontal.get_start()[1], 0), dash_length=0.2, color=self.scene.fontColor).shift(m.LEFT*6.5)
 
         if reverse:
             first_column_name = "Staging area"
             third_column_name = "Deleted changes"
 
-        firstColumnTitle = Text(first_column_name, font="Monospace", font_size=28, color=self.scene.fontColor).align_to(self.scene.camera.frame, LEFT).shift(RIGHT*0.65).shift(UP*self.zone_title_offset)
-        secondColumnTitle = Text(second_column_name, font="Monospace", font_size=28, color=self.scene.fontColor).move_to(self.scene.camera.frame.get_center()).align_to(firstColumnTitle, UP)
-        thirdColumnTitle = Text(third_column_name, font="Monospace", font_size=28, color=self.scene.fontColor).align_to(self.scene.camera.frame, RIGHT).shift(LEFT*1.65).align_to(firstColumnTitle, UP)
+        firstColumnTitle = m.Text(first_column_name, font="Monospace", font_size=28, color=self.scene.fontColor).align_to(self.scene.camera.frame, m.LEFT).shift(m.RIGHT*0.65).shift(m.UP*self.zone_title_offset)
+        secondColumnTitle = m.Text(second_column_name, font="Monospace", font_size=28, color=self.scene.fontColor).move_to(self.scene.camera.frame.get_center()).align_to(firstColumnTitle, m.UP)
+        thirdColumnTitle = m.Text(third_column_name, font="Monospace", font_size=28, color=self.scene.fontColor).align_to(self.scene.camera.frame,m.RIGHT).shift(m.LEFT*1.65).align_to(firstColumnTitle, m.UP)
 
         self.toFadeOut.add(horizontal, horizontal2, vert1, vert2, firstColumnTitle, secondColumnTitle, thirdColumnTitle)
 
         if self.scene.args.animate:
-            self.scene.play(Create(horizontal), Create(horizontal2), Create(vert1), Create(vert2), AddTextLetterByLetter(firstColumnTitle), AddTextLetterByLetter(secondColumnTitle), AddTextLetterByLetter(thirdColumnTitle)) 
+            self.scene.play(m.Create(horizontal), m.Create(horizontal2), m.Create(vert1), m.Create(vert2), m.AddTextLetterByLetter(firstColumnTitle), m.AddTextLetterByLetter(secondColumnTitle), m.AddTextLetterByLetter(thirdColumnTitle))
         else:
             self.scene.add(horizontal, horizontal2, vert1, vert2, firstColumnTitle, secondColumnTitle, thirdColumnTitle)
 
@@ -355,44 +360,44 @@ class GitSimBaseCommand():
 
         self.populate_zones(firstColumnFileNames, secondColumnFileNames, thirdColumnFileNames, firstColumnArrowMap, secondColumnArrowMap)
 
-        firstColumnFiles = VGroup()
-        secondColumnFiles = VGroup()
-        thirdColumnFiles = VGroup()
+        firstColumnFiles = m.VGroup()
+        secondColumnFiles = m.VGroup()
+        thirdColumnFiles = m.VGroup()
 
         firstColumnFilesDict = {}
         secondColumnFilesDict = {}
         thirdColumnFilesDict = {}
 
         for i, f in enumerate(firstColumnFileNames):
-            text = Text(f, font="Monospace", font_size=24, color=self.scene.fontColor).move_to((firstColumnTitle.get_center()[0], horizontal2.get_center()[1], 0)).shift(DOWN*0.5*(i+1))
+            text = m.Text(f, font="Monospace", font_size=24, color=self.scene.fontColor).move_to((firstColumnTitle.get_center()[0], horizontal2.get_center()[1], 0)).shift(m.DOWN*0.5*(i+1))
             firstColumnFiles.add(text)
             firstColumnFilesDict[f] = text
 
         for j, f in enumerate(secondColumnFileNames):
-            text = Text(f, font="Monospace", font_size=24, color=self.scene.fontColor).move_to((secondColumnTitle.get_center()[0], horizontal2.get_center()[1], 0)).shift(DOWN*0.5*(j+1))
+            text = m.Text(f, font="Monospace", font_size=24, color=self.scene.fontColor).move_to((secondColumnTitle.get_center()[0], horizontal2.get_center()[1], 0)).shift(m.DOWN*0.5*(j+1))
             secondColumnFiles.add(text)
             secondColumnFilesDict[f] = text
 
         for h, f in enumerate(thirdColumnFileNames):
-            text = Text(f, font="Monospace", font_size=24, color=self.scene.fontColor).move_to((thirdColumnTitle.get_center()[0], horizontal2.get_center()[1], 0)).shift(DOWN*0.5*(h+1))
+            text = m.Text(f, font="Monospace", font_size=24, color=self.scene.fontColor).move_to((thirdColumnTitle.get_center()[0], horizontal2.get_center()[1], 0)).shift(m.DOWN*0.5*(h+1))
             thirdColumnFiles.add(text)
             thirdColumnFilesDict[f] = text
 
         if len(firstColumnFiles):
             if self.scene.args.animate:
-                self.scene.play(*[AddTextLetterByLetter(d) for d in firstColumnFiles])
+                self.scene.play(*[m.AddTextLetterByLetter(d) for d in firstColumnFiles])
             else:
                 self.scene.add(*[d for d in firstColumnFiles])
 
         if len(secondColumnFiles):
             if self.scene.args.animate:
-                self.scene.play(*[AddTextLetterByLetter(w) for w in secondColumnFiles])
+                self.scene.play(*[m.AddTextLetterByLetter(w) for w in secondColumnFiles])
             else:
                 self.scene.add(*[w for w in secondColumnFiles])
 
         if len(thirdColumnFiles):
             if self.scene.args.animate:
-                self.scene.play(*[AddTextLetterByLetter(s) for s in thirdColumnFiles])
+                self.scene.play(*[m.AddTextLetterByLetter(s) for s in thirdColumnFiles])
             else:
                 self.scene.add(*[s for s in thirdColumnFiles])
 
@@ -402,7 +407,7 @@ class GitSimBaseCommand():
             else:
                 firstColumnArrowMap[filename].put_start_and_end_on((firstColumnFilesDict[filename].get_right()[0]+0.25, firstColumnFilesDict[filename].get_right()[1], 0), (thirdColumnFilesDict[filename].get_left()[0]-0.25, thirdColumnFilesDict[filename].get_left()[1], 0))
             if self.scene.args.animate:
-                self.scene.play(Create(firstColumnArrowMap[filename]))
+                self.scene.play(m.Create(firstColumnArrowMap[filename]))
             else:
                 self.scene.add(firstColumnArrowMap[filename])
             self.toFadeOut.add(firstColumnArrowMap[filename])
@@ -410,7 +415,7 @@ class GitSimBaseCommand():
         for filename in secondColumnArrowMap:
             secondColumnArrowMap[filename].put_start_and_end_on((secondColumnFilesDict[filename].get_right()[0]+0.25, secondColumnFilesDict[filename].get_right()[1], 0), (thirdColumnFilesDict[filename].get_left()[0]-0.25, thirdColumnFilesDict[filename].get_left()[1], 0))
             if self.scene.args.animate:
-                self.scene.play(Create(secondColumnArrowMap[filename]))
+                self.scene.play(m.Create(secondColumnArrowMap[filename]))
             else:
                 self.scene.add(secondColumnArrowMap[filename])
             self.toFadeOut.add(secondColumnArrowMap[filename])
@@ -456,27 +461,27 @@ class GitSimBaseCommand():
         else:
             self.scene.camera.frame.shift(shift)
 
-    def setup_and_draw_parent(self, child, commitMessage="New commit", shift=numpy.array([0., 0., 0.]), draw_arrow=True, color=RED):
-        circle = Circle(stroke_color=color, fill_color=color, fill_opacity=0.25)
-        circle.height = 1 
-        circle.next_to(self.drawnCommits[child.hexsha], LEFT if self.scene.args.reverse else RIGHT, buff=1.5)
+    def setup_and_draw_parent(self, child, commitMessage="New commit", shift=numpy.array([0., 0., 0.]), draw_arrow=True, color=m.RED):
+        circle = m.Circle(stroke_color=color, fill_color=color, fill_opacity=0.25)
+        circle.height = 1
+        circle.next_to(self.drawnCommits[child.hexsha], m.LEFT if self.scene.args.reverse else m.RIGHT, buff=1.5)
         circle.shift(shift)
 
         start = circle.get_center()
         end = self.drawnCommits[child.hexsha].get_center()
-        arrow = Arrow(start, end, color=self.scene.fontColor)
+        arrow = m.Arrow(start, end, color=self.scene.fontColor)
         length = numpy.linalg.norm(start-end) - ( 1.5 if start[1] == end[1] else 3  )
         arrow.set_length(length)
 
-        commitId = Text("abcdef", font="Monospace", font_size=20, color=self.scene.fontColor).next_to(circle, UP) 
+        commitId = m.Text("abcdef", font="Monospace", font_size=20, color=self.scene.fontColor).next_to(circle, m.UP)
         self.toFadeOut.add(commitId)
 
         commitMessage = commitMessage.split("\n")[0][:40].replace("\n", " ")
-        message = Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, DOWN)
+        message = m.Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, m.DOWN)
         self.toFadeOut.add(message)
 
         if self.scene.args.animate:
-            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), Create(circle), AddTextLetterByLetter(commitId), AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
+            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), m.Create(circle), m.AddTextLetterByLetter(commitId), m.AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
         else:
             self.scene.camera.frame.move_to(circle.get_center())
             self.scene.add(circle, commitId, message)
@@ -486,7 +491,7 @@ class GitSimBaseCommand():
 
         if draw_arrow:
             if self.scene.args.animate:
-                self.scene.play(Create(arrow), run_time=1/self.scene.args.speed)
+                self.scene.play(m.Create(arrow), run_time=1/self.scene.args.speed)
             else:
                 self.scene.add(arrow)
             self.toFadeOut.add(arrow)
@@ -512,16 +517,16 @@ class GitSimBaseCommand():
                 nondark_commits.append(commit)
         return nondark_commits
 
-    def draw_ref(self, commit, top, text="HEAD", color=BLUE):
-        refText = Text(text, font="Monospace", font_size=20, color=self.scene.fontColor)
-        refbox = Rectangle(color=color, fill_color=color, fill_opacity=0.25, height=0.4, width=refText.width+0.25)
-        refbox.next_to(top, UP) 
+    def draw_ref(self, commit, top, text="HEAD", color=m.BLUE):
+        refText = m.Text(text, font="Monospace", font_size=20, color=self.scene.fontColor)
+        refbox = m.Rectangle(color=color, fill_color=color, fill_opacity=0.25, height=0.4, width=refText.width+0.25)
+        refbox.next_to(top, m.UP)
         refText.move_to(refbox.get_center())
 
-        ref = VGroup(refbox, refText)
+        ref = m.VGroup(refbox, refText)
 
         if self.scene.args.animate:
-            self.scene.play(Create(ref), run_time=1/self.scene.args.speed)
+            self.scene.play(m.Create(ref), run_time=1/self.scene.args.speed)
         else:
             self.scene.add(ref)
 
@@ -533,24 +538,24 @@ class GitSimBaseCommand():
             self.topref = self.prevRef
 
     def draw_dark_ref(self):
-        refRec = Rectangle(color=WHITE if self.scene.args.light_mode else BLACK, fill_color=WHITE if self.scene.args.light_mode else BLACK, height=0.4, width=1)
-        refRec.next_to(self.prevRef, UP)
+        refRec = m.Rectangle(color=m.WHITE if self.scene.args.light_mode else m.BLACK, fill_color=m.WHITE if self.scene.args.light_mode else m.BLACK, height=0.4, width=1)
+        refRec.next_to(self.prevRef, m.UP)
         self.scene.add(refRec)
         self.toFadeOut.add(refRec)
         self.prevRef = refRec
 
 
-class DottedLine(Line):
+class DottedLine(m.Line):
 
     def __init__(self, *args, dot_spacing=0.4, dot_kwargs={}, **kwargs):
-        Line.__init__(self, *args, **kwargs)
+        m.Line.__init__(self, *args, **kwargs)
         n_dots = int(self.get_length() / dot_spacing) + 1
         dot_spacing = self.get_length() / (n_dots - 1)
         unit_vector = self.get_unit_vector()
         start = self.start
 
         self.dot_points = [start + unit_vector * dot_spacing * x for x in range(n_dots)]
-        self.dots = [Dot(point, **dot_kwargs) for point in self.dot_points]
+        self.dots = [m.Dot(point, **dot_kwargs) for point in self.dot_points]
 
         self.clear_points()
 

--- a/git_sim/git_sim_branch.py
+++ b/git_sim/git_sim_branch.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimBranch(GitSimBaseCommand):
     def __init__(self, scene):
@@ -15,16 +20,16 @@ class GitSimBranch(GitSimBaseCommand):
         self.recenter_frame()
         self.scale_frame()
 
-        branchText = Text(self.scene.args.name, font="Monospace", font_size=20, color=self.scene.fontColor)
-        branchRec = Rectangle(color=GREEN, fill_color=GREEN, fill_opacity=0.25, height=0.4, width=branchText.width+0.25)
+        branchText = m.Text(self.scene.args.name, font="Monospace", font_size=20, color=self.scene.fontColor)
+        branchRec = m.Rectangle(color=m.GREEN, fill_color=m.GREEN, fill_opacity=0.25, height=0.4, width=branchText.width+0.25)
 
-        branchRec.next_to(self.topref, UP) 
+        branchRec.next_to(self.topref, m.UP)
         branchText.move_to(branchRec.get_center())
 
-        fullbranch = VGroup(branchRec, branchText)
+        fullbranch = m.VGroup(branchRec, branchText)
 
         if self.scene.args.animate:
-            self.scene.play(Create(fullbranch), run_time=1/self.scene.args.speed)
+            self.scene.play(m.Create(fullbranch), run_time=1/self.scene.args.speed)
         else:
             self.scene.add(fullbranch)
 

--- a/git_sim/git_sim_cherrypick.py
+++ b/git_sim/git_sim_cherrypick.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimCherryPick(GitSimBaseCommand):
     def __init__(self, scene):
@@ -32,7 +37,7 @@ class GitSimCherryPick(GitSimBaseCommand):
         self.parse_commits(self.commits[0])
         self.orig_commits = self.commits
         self.get_commits(start=self.scene.args.commit[0])
-        self.parse_commits(self.commits[0], shift=4*DOWN)
+        self.parse_commits(self.commits[0], shift=4*m.DOWN)
         self.center_frame_on_commit(self.orig_commits[0])
         self.setup_and_draw_parent(self.orig_commits[0], self.commits[0].message)
         self.draw_arrow_between_commits(self.commits[0].hexsha, "abcdef")

--- a/git_sim/git_sim_commit.py
+++ b/git_sim/git_sim_commit.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimCommit(GitSimBaseCommand):
     def __init__(self, scene):
@@ -41,4 +46,4 @@ class GitSimCommit(GitSimBaseCommand):
             if "git-sim_media" not in y.a_path:
                 secondColumnFileNames.add(y.a_path)
                 thirdColumnFileNames.add(y.a_path)
-                secondColumnArrowMap[y.a_path] = Arrow(stroke_width=3, color=self.scene.fontColor)
+                secondColumnArrowMap[y.a_path] = m.Arrow(stroke_width=3, color=self.scene.fontColor)

--- a/git_sim/git_sim_log.py
+++ b/git_sim/git_sim_log.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimLog(GitSimBaseCommand):
     def __init__(self, scene):

--- a/git_sim/git_sim_merge.py
+++ b/git_sim/git_sim_merge.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimMerge(GitSimBaseCommand):
     def __init__(self, scene):
@@ -55,15 +60,15 @@ class GitSimMerge(GitSimBaseCommand):
                 self.reset_head_branch(reset_head_to, shift=shift)
             else:
                 self.draw_ref(self.commits[0], commitId if self.scene.args.no_ff else self.topref)
-                self.draw_ref(self.commits[0], self.drawnRefs["HEAD"] if self.scene.args.no_ff else self.topref, text=self.repo.active_branch.name, color=GREEN)
+                self.draw_ref(self.commits[0], self.drawnRefs["HEAD"] if self.scene.args.no_ff else self.topref, text=self.repo.active_branch.name, color=m.GREEN)
 
         else:
             self.get_commits()
             self.parse_commits(self.commits[0])
             self.get_commits(start=self.scene.args.branch[0])
-            self.parse_commits(self.commits[0], shift=4*DOWN)
+            self.parse_commits(self.commits[0], shift=4*m.DOWN)
             self.center_frame_on_commit(self.orig_commits[0])
-            self.setup_and_draw_parent(self.orig_commits[0], "Merge commit", shift=2*DOWN, draw_arrow=False, color=GRAY)
+            self.setup_and_draw_parent(self.orig_commits[0], "Merge commit", shift=2*m.DOWN, draw_arrow=False, color=m.GRAY)
             self.draw_arrow_between_commits("abcdef", self.commits[0].hexsha)
             self.draw_arrow_between_commits("abcdef", self.orig_commits[0].hexsha)
             self.recenter_frame()

--- a/git_sim/git_sim_rebase.py
+++ b/git_sim/git_sim_rebase.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimRebase(GitSimBaseCommand):
     def __init__(self, scene):
@@ -36,13 +41,13 @@ class GitSimRebase(GitSimBaseCommand):
         self.parse_commits(self.commits[0])
         self.orig_commits = self.commits
         self.get_commits()
-        self.parse_commits(self.commits[0], shift=4*DOWN)
+        self.parse_commits(self.commits[0], shift=4*m.DOWN)
         self.center_frame_on_commit(self.orig_commits[0])
 
         to_rebase = []
         i = 0
         current = self.commits[i]
-        while self.scene.args.branch[0] not in self.repo.git.branch("--contains", current): 
+        while self.scene.args.branch[0] not in self.repo.git.branch("--contains", current):
             to_rebase.append(current)
             i += 1
             current = self.commits[i]
@@ -51,7 +56,7 @@ class GitSimRebase(GitSimBaseCommand):
         for tr in reversed(to_rebase):
             parent = self.setup_and_draw_parent(parent, tr.message)
             self.draw_arrow_between_commits(tr.hexsha, parent)
-                         
+
         self.recenter_frame()
         self.scale_frame()
         self.reset_head_branch(parent)
@@ -59,26 +64,26 @@ class GitSimRebase(GitSimBaseCommand):
         self.show_outro()
 
     def setup_and_draw_parent(self, child, commitMessage="New commit", shift=numpy.array([0., 0., 0.]), draw_arrow=True):
-        circle = Circle(stroke_color=RED, fill_color=RED, fill_opacity=0.25)
-        circle.height = 1 
-        circle.next_to(self.drawnCommits[child], LEFT if self.scene.args.reverse else RIGHT, buff=1.5)
+        circle = m.Circle(stroke_color=m.RED, fill_color=m.RED, fill_opacity=0.25)
+        circle.height = 1
+        circle.next_to(self.drawnCommits[child], m.LEFT if self.scene.args.reverse else m.RIGHT, buff=1.5)
         circle.shift(shift)
 
         start = circle.get_center()
         end = self.drawnCommits[child].get_center()
-        arrow = Arrow(start, end, color=self.scene.fontColor)
+        arrow = m.Arrow(start, end, color=self.scene.fontColor)
         length = numpy.linalg.norm(start-end) - ( 1.5 if start[1] == end[1] else 3  )
         arrow.set_length(length)
         sha = "".join(chr(ord(letter)+1) if (chr(ord(letter)+1).isalpha() or chr(ord(letter)+1).isdigit()) else letter for letter in child[:6])
-        commitId = Text(sha, font="Monospace", font_size=20, color=self.scene.fontColor).next_to(circle, UP) 
+        commitId = m.Text(sha, font="Monospace", font_size=20, color=self.scene.fontColor).next_to(circle, m.UP)
         self.toFadeOut.add(commitId)
 
         commitMessage = commitMessage[:40].replace("\n", " ")
-        message = Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, DOWN)
+        message = m.Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, m.DOWN)
         self.toFadeOut.add(message)
 
         if self.scene.args.animate:
-            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), Create(circle), AddTextLetterByLetter(commitId), AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
+            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), m.Create(circle), m.AddTextLetterByLetter(commitId), m.AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
         else:
             self.scene.camera.frame.move_to(circle.get_center())
             self.scene.add(circle, commitId, message)
@@ -88,7 +93,7 @@ class GitSimRebase(GitSimBaseCommand):
 
         if draw_arrow:
             if self.scene.args.animate:
-                self.scene.play(Create(arrow), run_time=1/self.scene.args.speed)
+                self.scene.play(m.Create(arrow), run_time=1/self.scene.args.speed)
             else:
                 self.scene.add(arrow)
             self.toFadeOut.add(arrow)

--- a/git_sim/git_sim_reset.py
+++ b/git_sim/git_sim_reset.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimReset(GitSimBaseCommand):
     def __init__(self, scene):
@@ -45,19 +50,19 @@ class GitSimReset(GitSimBaseCommand):
     def build_commit_id_and_message(self, commit):
         hide_refs = False
         if commit == "dark":
-            commitId = Text('', font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text('', font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = ''
         elif self.i == 3 and self.resetTo.hexsha not in [commit.hexsha for commit in self.get_nondark_commits()]:
-            commitId = Text('...', font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text('...', font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = '...'
             hide_refs = True
         elif self.i == 4 and self.resetTo.hexsha not in [commit.hexsha for commit in self.get_nondark_commits()]:
-            commitId = Text(self.resetTo.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text(self.resetTo.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = self.resetTo.message.split("\n")[0][:40].replace("\n", " ")
             commit = self.resetTo
             hide_refs = True
         else:
-            commitId = Text(commit.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text(commit.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = commit.message.split("\n")[0][:40].replace("\n", " ")
 
         if commit != "dark" and commit.hexsha == self.resetTo.hexsha and commit.hexsha != self.repo.head.commit.hexsha:

--- a/git_sim/git_sim_restore.py
+++ b/git_sim/git_sim_restore.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimRestore(GitSimBaseCommand):
     def __init__(self, scene):
@@ -39,7 +44,7 @@ class GitSimRestore(GitSimBaseCommand):
                 for name in self.scene.args.name:
                     if name == x.a_path:
                         thirdColumnFileNames.add(x.a_path)
-                        secondColumnArrowMap[x.a_path] = Arrow(stroke_width=3, color=self.scene.fontColor)
+                        secondColumnArrowMap[x.a_path] = m.Arrow(stroke_width=3, color=self.scene.fontColor)
 
         for y in self.repo.index.diff("HEAD"):
             if "git-sim_media" not in y.a_path:
@@ -47,4 +52,4 @@ class GitSimRestore(GitSimBaseCommand):
                 for name in self.scene.args.name:
                     if name == y.a_path:
                         secondColumnFileNames.add(y.a_path)
-                        firstColumnArrowMap[y.a_path] = Arrow(stroke_width=3, color=self.scene.fontColor)
+                        firstColumnArrowMap[y.a_path] = m.Arrow(stroke_width=3, color=self.scene.fontColor)

--- a/git_sim/git_sim_revert.py
+++ b/git_sim/git_sim_revert.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimRevert(GitSimBaseCommand):
     def __init__(self, scene):
@@ -42,42 +47,42 @@ class GitSimRevert(GitSimBaseCommand):
     def build_commit_id_and_message(self, commit):
         hide_refs = False
         if commit == "dark":
-            commitId = Text('', font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text('', font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = ''
         elif self.i == 2 and self.revert.hexsha not in [commit.hexsha for commit in self.commits]:
-            commitId = Text('...', font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text('...', font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = '...'
             hide_refs = True
         elif self.i == 3 and self.revert.hexsha not in [commit.hexsha for commit in self.commits]:
-            commitId = Text(self.revert.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text(self.revert.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = self.revert.message.split("\n")[0][:40].replace("\n", " ")
             hide_refs = True
         else:
-            commitId = Text(commit.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
+            commitId = m.Text(commit.hexsha[:6], font="Monospace", font_size=20, color=self.scene.fontColor)
             commitMessage = commit.message.split("\n")[0][:40].replace("\n", " ")
         return commitId, commitMessage, commit, hide_refs
 
     def setup_and_draw_revert_commit(self):
-        circle = Circle(stroke_color=RED, fill_color=RED, fill_opacity=0.25)
-        circle.height = 1 
-        circle.next_to(self.drawnCommits[self.commits[0].hexsha], LEFT if self.scene.args.reverse else RIGHT, buff=1.5)
+        circle = m.Circle(stroke_color=m.RED, fill_color=m.RED, fill_opacity=0.25)
+        circle.height = 1
+        circle.next_to(self.drawnCommits[self.commits[0].hexsha], m.LEFT if self.scene.args.reverse else m.RIGHT, buff=1.5)
 
         start = circle.get_center()
         end = self.drawnCommits[self.commits[0].hexsha].get_center()
-        arrow = Arrow(start, end, color=self.scene.fontColor)
+        arrow = m.Arrow(start, end, color=self.scene.fontColor)
         length = numpy.linalg.norm(start-end) - ( 1.5 if start[1] == end[1] else 3  )
         arrow.set_length(length)
 
-        commitId = Text("abcdef", font="Monospace", font_size=20, color=self.scene.fontColor).next_to(circle, UP) 
+        commitId = m.Text("abcdef", font="Monospace", font_size=20, color=self.scene.fontColor).next_to(circle, m.UP)
         self.toFadeOut.add(commitId)
 
         commitMessage = "Revert " + self.revert.hexsha[0:6]
         commitMessage = commitMessage[:40].replace("\n", " ")
-        message = Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, DOWN)
+        message = m.Text('\n'.join(commitMessage[j:j+20] for j in range(0, len(commitMessage), 20))[:100], font="Monospace", font_size=14, color=self.scene.fontColor).next_to(circle, m.DOWN)
         self.toFadeOut.add(message)
 
         if self.scene.args.animate:
-            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), Create(circle), AddTextLetterByLetter(commitId), AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
+            self.scene.play(self.scene.camera.frame.animate.move_to(circle.get_center()), m.Create(circle), m.AddTextLetterByLetter(commitId), m.AddTextLetterByLetter(message), run_time=1/self.scene.args.speed)
         else:
             self.scene.camera.frame.move_to(circle.get_center())
             self.scene.add(circle, commitId, message)
@@ -86,7 +91,7 @@ class GitSimRevert(GitSimBaseCommand):
         self.toFadeOut.add(circle)
 
         if self.scene.args.animate:
-            self.scene.play(Create(arrow), run_time=1/self.scene.args.speed)
+            self.scene.play(m.Create(arrow), run_time=1/self.scene.args.speed)
         else:
             self.scene.add(arrow)
 

--- a/git_sim/git_sim_stash.py
+++ b/git_sim/git_sim_stash.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimStash(GitSimBaseCommand):
     def __init__(self, scene):
@@ -41,11 +46,11 @@ class GitSimStash(GitSimBaseCommand):
             for name in self.scene.args.name:
                 if name == x.a_path:
                     thirdColumnFileNames.add(x.a_path)
-                    firstColumnArrowMap[x.a_path] = Arrow(stroke_width=3, color=self.scene.fontColor)
+                    firstColumnArrowMap[x.a_path] = m.Arrow(stroke_width=3, color=self.scene.fontColor)
 
         for y in self.repo.index.diff("HEAD"):
             secondColumnFileNames.add(y.a_path)
             for name in self.scene.args.name:
                 if name == y.a_path:
                     thirdColumnFileNames.add(y.a_path)
-                    secondColumnArrowMap[y.a_path] = Arrow(stroke_width=3, color=self.scene.fontColor)
+                    secondColumnArrowMap[y.a_path] = m.Arrow(stroke_width=3, color=self.scene.fontColor)

--- a/git_sim/git_sim_status.py
+++ b/git_sim/git_sim_status.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimStatus(GitSimBaseCommand):
     def __init__(self, scene):

--- a/git_sim/git_sim_tag.py
+++ b/git_sim/git_sim_tag.py
@@ -1,6 +1,11 @@
-from manim import *
+import sys
+
+import git
+import manim as m
+import numpy
+
 from git_sim.git_sim_base_command import GitSimBaseCommand
-import git, sys, numpy
+
 
 class GitSimTag(GitSimBaseCommand):
     def __init__(self, scene):
@@ -15,16 +20,16 @@ class GitSimTag(GitSimBaseCommand):
         self.recenter_frame()
         self.scale_frame()
 
-        tagText = Text(self.scene.args.name, font="Monospace", font_size=20, color=self.scene.fontColor)
-        tagRec = Rectangle(color=YELLOW, fill_color=YELLOW, fill_opacity=0.25, height=0.4, width=tagText.width+0.25)
+        tagText = m.Text(self.scene.args.name, font="Monospace", font_size=20, color=self.scene.fontColor)
+        tagRec = m.Rectangle(color=m.YELLOW, fill_color=m.YELLOW, fill_opacity=0.25, height=0.4, width=tagText.width+0.25)
 
-        tagRec.next_to(self.topref, UP) 
+        tagRec.next_to(self.topref, m.UP)
         tagText.move_to(tagRec.get_center())
 
-        fulltag = VGroup(tagRec, tagText)
+        fulltag = m.VGroup(tagRec, tagText)
 
         if self.scene.args.animate:
-            self.scene.play(Create(fulltag), run_time=1/self.scene.args.speed)
+            self.scene.play(m.Create(fulltag), run_time=1/self.scene.args.speed)
         else:
             self.scene.add(fulltag)
 


### PR DESCRIPTION
Clean up star (wildcard) imports for better readability and to avoid namespace cluttering.

Replace all instances of `from manim import *` with `import manim as m` and prefix all Manim-Objects with `m.` accordingly.

Fixes #8 