### PR TITLE
update name to cherry-pick

### DIFF
--- a/git_sim/__main__.py
+++ b/git_sim/__main__.py
@@ -125,7 +125,7 @@ def main(
 
 app.command()(git_sim.add.add)
 app.command()(git_sim.branch.branch)
-app.command()(git_sim.cherrypick.cherrypick)
+app.command()(git_sim.cherrypick.cherry_pick)
 app.command()(git_sim.commit.commit)
 app.command()(git_sim.log.log)
 app.command()(git_sim.merge.merge)

--- a/git_sim/cherrypick.py
+++ b/git_sim/cherrypick.py
@@ -70,7 +70,7 @@ class CherryPick(GitSimBaseCommand):
         self.show_outro()
 
 
-def cherrypick(
+def cherry_pick(
     commit: str = typer.Argument(
         ...,
         help="The ref (branch/tag), or commit ID to simulate cherry-pick onto active branch",


### PR DESCRIPTION
This changes the name of the cherrypick command back to `cherry-pick` as discussed in #43 