### PR TITLE
Use pydantic settings

### DIFF
--- a/git_sim/__main__.py
+++ b/git_sim/__main__.py
@@ -21,7 +21,7 @@ import git_sim.revert
 import git_sim.stash
 import git_sim.status
 import git_sim.tag
-from git_sim.settings import ImgFormat, Settings, VideoFormat
+from git_sim.settings import ImgFormat, VideoFormat, settings
 
 app = typer.Typer()
 
@@ -29,98 +29,98 @@ app = typer.Typer()
 @app.callback(no_args_is_help=True)
 def main(
     animate: bool = typer.Option(
-        Settings.animate,
+        settings.animate,
         help="Animate the simulation and output as an mp4 video",
     ),
     auto_open: bool = typer.Option(
-        Settings.auto_open,
+        settings.auto_open,
         "--auto-open",
         " /-d",
         help="Enable / disable the automatic opening of the image/video file after generation",
     ),
     img_format: ImgFormat = typer.Option(
-        Settings.img_format,
+        settings.img_format,
         help="Output format for the image files.",
     ),
     light_mode: bool = typer.Option(
-        Settings.light_mode,
+        settings.light_mode,
         "--light-mode",
         help="Enable light-mode with white background",
     ),
     logo: pathlib.Path = typer.Option(
-        Settings.logo,
+        settings.logo,
         help="The path to a custom logo to use in the animation intro/outro",
     ),
     low_quality: bool = typer.Option(
-        Settings.low_quality,
+        settings.low_quality,
         "--low-quality",
         help="Render output video in low quality, useful for faster testing",
     ),
     max_branches_per_commit: int = typer.Option(
-        Settings.max_branches_per_commit,
+        settings.max_branches_per_commit,
         help="Maximum number of branch labels to display for each commit",
     ),
     max_tags_per_commit: int = typer.Option(
-        Settings.max_tags_per_commit,
+        settings.max_tags_per_commit,
         help="Maximum number of tags to display for each commit",
     ),
     media_dir: pathlib.Path = typer.Option(
-        Settings.media_dir,
+        settings.media_dir,
         help="The path to output the animation data and video file",
     ),
     outro_bottom_text: str = typer.Option(
-        Settings.outro_bottom_text,
+        settings.outro_bottom_text,
         help="Custom text to display below the logo during the outro",
     ),
     outro_top_text: str = typer.Option(
-        Settings.outro_top_text,
+        settings.outro_top_text,
         help="Custom text to display above the logo during the outro",
     ),
     reverse: bool = typer.Option(
-        Settings.reverse,
+        settings.reverse,
         "--reverse",
         "-r",
         help="Display commit history in the reverse direction",
     ),
     show_intro: bool = typer.Option(
-        Settings.show_intro,
+        settings.show_intro,
         help="Add an intro sequence with custom logo and title",
     ),
     show_outro: bool = typer.Option(
-        Settings.show_outro,
+        settings.show_outro,
         help="Add an outro sequence with custom logo and text",
     ),
     speed: float = typer.Option(
-        Settings.speed,
+        settings.speed,
         help="A multiple of the standard 1x animation speed (ex: 2 = twice as fast, 0.5 = half as fast)",
     ),
     title: str = typer.Option(
-        Settings.title,
+        settings.title,
         help="Custom title to display at the beginning of the animation",
     ),
     video_format: VideoFormat = typer.Option(
-        Settings.video_format.value,
+        settings.video_format.value,
         help="Output format for the animation files.",
         case_sensitive=False,
     ),
 ):
-    Settings.animate = animate
-    Settings.auto_open = auto_open
-    Settings.img_format = img_format
-    Settings.light_mode = light_mode
-    Settings.logo = logo
-    Settings.low_quality = low_quality
-    Settings.max_branches_per_commit = max_branches_per_commit
-    Settings.max_tags_per_commit = max_tags_per_commit
-    Settings.media_dir = media_dir
-    Settings.outro_bottom_text = outro_bottom_text
-    Settings.outro_top_text = outro_top_text
-    Settings.reverse = reverse
-    Settings.show_intro = show_intro
-    Settings.show_outro = show_outro
-    Settings.speed = speed
-    Settings.title = title
-    Settings.video_format = video_format
+    settings.animate = animate
+    settings.auto_open = auto_open
+    settings.img_format = img_format
+    settings.light_mode = light_mode
+    settings.logo = logo
+    settings.low_quality = low_quality
+    settings.max_branches_per_commit = max_branches_per_commit
+    settings.max_tags_per_commit = max_tags_per_commit
+    settings.media_dir = media_dir
+    settings.outro_bottom_text = outro_bottom_text
+    settings.outro_top_text = outro_top_text
+    settings.reverse = reverse
+    settings.show_intro = show_intro
+    settings.show_outro = show_outro
+    settings.speed = speed
+    settings.title = title
+    settings.video_format = video_format
 
 
 app.command()(git_sim.add.add)

--- a/git_sim/add.py
+++ b/git_sim/add.py
@@ -6,7 +6,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Add(GitSimBaseCommand):
@@ -30,7 +30,7 @@ class Add(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()} {' '.join(self.files)}"
+            f"{settings.INFO_STRING} {type(self).__name__.lower()} {' '.join(self.files)}"
         )
 
         self.show_intro()

--- a/git_sim/animations.py
+++ b/git_sim/animations.py
@@ -11,7 +11,7 @@ import git.repo
 from manim import WHITE, Scene, config
 from manim.utils.file_ops import open_file
 
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 def handle_animations(scene: Scene) -> None:
@@ -25,22 +25,22 @@ def handle_animations(scene: Scene) -> None:
         ).working_tree_dir.split("\\")[-1]
 
     config.media_dir = os.path.join(
-        os.path.expanduser(Settings.media_dir), "git-sim_media"
+        os.path.expanduser(settings.media_dir), "git-sim_media"
     )
     config.verbosity = "ERROR"
 
     # If the env variable is set and no argument provided, use the env variable value
-    if os.getenv("git_sim_media_dir") and Settings.media_dir == ".":
+    if os.getenv("git_sim_media_dir") and settings.media_dir == ".":
         config.media_dir = os.path.join(
             os.path.expanduser(os.getenv("git_sim_media_dir")),
             "git-sim_media",
             repo_name,
         )
 
-    if Settings.low_quality:
+    if settings.low_quality:
         config.quality = "low_quality"
 
-    if Settings.light_mode:
+    if settings.light_mode:
         config.background_color = WHITE
 
     t = datetime.datetime.fromtimestamp(time.time()).strftime("%m-%d-%y_%H-%M-%S")
@@ -48,7 +48,7 @@ def handle_animations(scene: Scene) -> None:
 
     scene.render()
 
-    if Settings.video_format == "webm":
+    if settings.video_format == "webm":
         webm_file_path = str(scene.renderer.file_writer.movie_file_path)[:-3] + "webm"
         cmd = f"ffmpeg -y -i {scene.renderer.file_writer.movie_file_path} -hide_banner -loglevel error -c:v libvpx-vp9 -crf 50 -b:v 0 -b:a 128k -c:a libopus {webm_file_path}"
         print("Converting video output to .webm format...")
@@ -60,7 +60,7 @@ def handle_animations(scene: Scene) -> None:
             os.remove(scene.renderer.file_writer.movie_file_path)
             scene.renderer.file_writer.movie_file_path = webm_file_path
 
-    if not Settings.animate:
+    if not settings.animate:
         video = cv2.VideoCapture(str(scene.renderer.file_writer.movie_file_path))
         success, image = video.read()
         if success:
@@ -70,7 +70,7 @@ def handle_animations(scene: Scene) -> None:
                 + "_"
                 + t
                 + "."
-                + Settings.img_format
+                + settings.img_format
             )
             image_file_path = os.path.join(
                 os.path.join(config.media_dir, "images"), image_file_name
@@ -80,9 +80,9 @@ def handle_animations(scene: Scene) -> None:
     else:
         print("Output video location:", scene.renderer.file_writer.movie_file_path)
 
-    if Settings.auto_open:
+    if settings.auto_open:
         try:
-            if not Settings.animate:
+            if not settings.animate:
                 open_file(image_file_path)
             else:
                 open_file(scene.renderer.file_writer.movie_file_path)

--- a/git_sim/animations.py
+++ b/git_sim/animations.py
@@ -29,14 +29,6 @@ def handle_animations(scene: Scene) -> None:
     )
     config.verbosity = "ERROR"
 
-    # If the env variable is set and no argument provided, use the env variable value
-    if os.getenv("git_sim_media_dir") and settings.media_dir == ".":
-        config.media_dir = os.path.join(
-            os.path.expanduser(os.getenv("git_sim_media_dir")),
-            "git-sim_media",
-            repo_name,
-        )
-
     if settings.low_quality:
         config.quality = "low_quality"
 

--- a/git_sim/branch.py
+++ b/git_sim/branch.py
@@ -3,7 +3,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Branch(GitSimBaseCommand):
@@ -12,7 +12,7 @@ class Branch(GitSimBaseCommand):
         self.name = name
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()} {self.name}")
+        print(f"{settings.INFO_STRING} {type(self).__name__.lower()} {self.name}")
 
         self.show_intro()
         self.get_commits()
@@ -39,8 +39,8 @@ class Branch(GitSimBaseCommand):
 
         fullbranch = m.VGroup(branchRec, branchText)
 
-        if Settings.animate:
-            self.play(m.Create(fullbranch), run_time=1 / Settings.speed)
+        if settings.animate:
+            self.play(m.Create(fullbranch), run_time=1 / settings.speed)
         else:
             self.add(fullbranch)
 

--- a/git_sim/cherrypick.py
+++ b/git_sim/cherrypick.py
@@ -6,7 +6,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class CherryPick(GitSimBaseCommand):
@@ -35,7 +35,7 @@ class CherryPick(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()} {self.commit}"
+            f"{settings.INFO_STRING} {type(self).__name__.lower()} {self.commit}"
             + ((' -e "' + self.edit + '"') if self.edit else "")
         )
 

--- a/git_sim/commit.py
+++ b/git_sim/commit.py
@@ -3,10 +3,10 @@ import sys
 import git
 import manim as m
 import typer
-from git_sim.animations import handle_animations
-from git_sim.settings import Settings
 
+from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
+from git_sim.settings import settings
 
 
 class Commit(GitSimBaseCommand):
@@ -32,7 +32,7 @@ class Commit(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()} {'--amend ' if self.amend else ''}"
+            f"{settings.INFO_STRING } {type(self).__name__.lower()} {'--amend ' if self.amend else ''}"
             + '-m "'
             + self.message
             + '"'

--- a/git_sim/git_sim_base_command.py
+++ b/git_sim/git_sim_base_command.py
@@ -7,7 +7,7 @@ import numpy
 from git.exc import GitCommandError, InvalidGitRepositoryError
 from git.repo import Repo
 
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class GitSimBaseCommand(m.MovingCameraScene):
@@ -15,7 +15,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
         super().__init__()
         self.init_repo()
 
-        self.fontColor = m.BLACK if Settings.light_mode else m.WHITE
+        self.fontColor = m.BLACK if settings.light_mode else m.WHITE
         self.drawnCommits = {}
         self.drawnRefs = {}
         self.drawnCommitIds = {}
@@ -26,13 +26,13 @@ class GitSimBaseCommand(m.MovingCameraScene):
         self.prevRef = None
         self.topref = None
         self.i = 0
-        self.numCommits = Settings.commits
-        self.defaultNumCommits = Settings.commits
+        self.numCommits = settings.commits
+        self.defaultNumCommits = settings.commits
         self.selected_branches = []
         self.stop = False
         self.zone_title_offset = 2.6 if platform.system() == "Windows" else 2.6
 
-        self.logo = m.ImageMobject(Settings.logo)
+        self.logo = m.ImageMobject(settings.logo)
         self.logo.width = 3
 
     def init_repo(self):
@@ -43,7 +43,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
             sys.exit(1)
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()}")
+        print(f"{settings.INFO_STRING} {type(self).__name__.lower()}")
         self.show_intro()
         self.get_commits()
         self.fadeout()
@@ -51,7 +51,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
     def get_commits(self, start="HEAD"):
         if not self.numCommits:
-            if Settings.allow_no_commits:
+            if settings.allow_no_commits:
                 self.numCommits = self.defaultNumCommits
                 self.commits = ["dark"] * 5
                 self.zone_title_offset = 2
@@ -108,11 +108,11 @@ class GitSimBaseCommand(m.MovingCameraScene):
                 self.i = 0
 
     def show_intro(self):
-        if Settings.animate and Settings.show_intro:
+        if settings.animate and settings.show_intro:
             self.add(self.logo)
 
             initialCommitText = m.Text(
-                Settings.title,
+                settings.title,
                 font="Monospace",
                 font_size=36,
                 color=self.fontColor,
@@ -134,13 +134,13 @@ class GitSimBaseCommand(m.MovingCameraScene):
             self.camera.frame.save_state()
 
     def show_outro(self):
-        if Settings.animate and Settings.show_outro:
+        if settings.animate and settings.show_outro:
             self.play(m.Restore(self.camera.frame))
 
             self.play(self.logo.animate.scale(4).set_x(0).set_y(0))
 
             outroTopText = m.Text(
-                Settings.outro_top_text,
+                settings.outro_top_text,
                 font="Monospace",
                 font_size=36,
                 color=self.fontColor,
@@ -148,7 +148,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
             self.play(m.AddTextLetterByLetter(outroTopText))
 
             outroBottomText = m.Text(
-                Settings.outro_bottom_text,
+                settings.outro_bottom_text,
                 font="Monospace",
                 font_size=36,
                 color=self.fontColor,
@@ -158,9 +158,9 @@ class GitSimBaseCommand(m.MovingCameraScene):
             self.wait(3)
 
     def fadeout(self):
-        if Settings.animate:
+        if settings.animate:
             self.wait(3)
-            self.play(m.FadeOut(self.toFadeOut), run_time=1 / Settings.speed)
+            self.play(m.FadeOut(self.toFadeOut), run_time=1 / settings.speed)
         else:
             self.wait(0.1)
 
@@ -174,7 +174,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
         self, commit, prevCircle, shift=numpy.array([0.0, 0.0, 0.0]), dots=False
     ):
         if commit == "dark":
-            commitFill = m.WHITE if Settings.light_mode else m.BLACK
+            commitFill = m.WHITE if settings.light_mode else m.BLACK
         elif len(commit.parents) <= 1:
             commitFill = m.RED
         else:
@@ -190,19 +190,19 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
         if prevCircle:
             circle.next_to(
-                prevCircle, m.RIGHT if Settings.reverse else m.LEFT, buff=1.5
+                prevCircle, m.RIGHT if settings.reverse else m.LEFT, buff=1.5
             )
 
         start = (
             prevCircle.get_center()
             if prevCircle
-            else (m.LEFT if Settings.reverse else m.RIGHT)
+            else (m.LEFT if settings.reverse else m.RIGHT)
         )
         end = circle.get_center()
 
         if commit == "dark":
             arrow = m.Arrow(
-                start, end, color=m.WHITE if Settings.light_mode else m.BLACK
+                start, end, color=m.WHITE if settings.light_mode else m.BLACK
             )
         elif commit.hexsha in self.drawnCommits:
             end = self.drawnCommits[commit.hexsha].get_center()
@@ -231,13 +231,13 @@ class GitSimBaseCommand(m.MovingCameraScene):
             color=self.fontColor,
         ).next_to(circle, m.DOWN)
 
-        if Settings.animate and commit != "dark" and not self.stop:
+        if settings.animate and commit != "dark" and not self.stop:
             self.play(
                 self.camera.frame.animate.move_to(circle.get_center()),
                 m.Create(circle),
                 m.AddTextLetterByLetter(commitId),
                 m.AddTextLetterByLetter(message),
-                run_time=1 / Settings.speed,
+                run_time=1 / settings.speed,
             )
         elif not self.stop:
             self.add(circle, commitId, message)
@@ -288,8 +288,8 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
             head = m.VGroup(headbox, headText)
 
-            if Settings.animate:
-                self.play(m.Create(head), run_time=1 / Settings.speed)
+            if settings.animate:
+                self.play(m.Create(head), run_time=1 / settings.speed)
             else:
                 self.add(head)
 
@@ -340,8 +340,8 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
                 self.prevRef = fullbranch
 
-                if Settings.animate:
-                    self.play(m.Create(fullbranch), run_time=1 / Settings.speed)
+                if settings.animate:
+                    self.play(m.Create(fullbranch), run_time=1 / settings.speed)
                 else:
                     self.add(fullbranch)
 
@@ -352,13 +352,13 @@ class GitSimBaseCommand(m.MovingCameraScene):
                     self.topref = self.prevRef
 
                 x += 1
-                if x >= Settings.max_branches_per_commit:
+                if x >= settings.max_branches_per_commit:
                     return
 
     def draw_tag(self, commit):
         x = 0
 
-        if Settings.hide_first_tag and self.i == 0:
+        if settings.hide_first_tag and self.i == 0:
             return
 
         for tag in self.repo.tags:
@@ -383,11 +383,11 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
                     self.prevRef = tagRec
 
-                    if Settings.animate:
+                    if settings.animate:
                         self.play(
                             m.Create(tagRec),
                             m.Create(tagText),
-                            run_time=1 / Settings.speed,
+                            run_time=1 / settings.speed,
                         )
                     else:
                         self.add(tagRec, tagText)
@@ -398,43 +398,43 @@ class GitSimBaseCommand(m.MovingCameraScene):
                         self.topref = self.prevRef
 
                     x += 1
-                    if x >= Settings.max_tags_per_commit:
+                    if x >= settings.max_tags_per_commit:
                         return
             except ValueError:
                 pass
 
     def draw_arrow(self, prevCircle, arrow):
         if prevCircle:
-            if Settings.animate:
-                self.play(m.Create(arrow), run_time=1 / Settings.speed)
+            if settings.animate:
+                self.play(m.Create(arrow), run_time=1 / settings.speed)
             else:
                 self.add(arrow)
 
             self.toFadeOut.add(arrow)
 
     def recenter_frame(self):
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.move_to(self.toFadeOut.get_center()),
-                run_time=1 / Settings.speed,
+                run_time=1 / settings.speed,
             )
         else:
             self.camera.frame.move_to(self.toFadeOut.get_center())
 
     def scale_frame(self):
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.scale_to_fit_width(
                     self.toFadeOut.get_width() * 1.1
                 ),
-                run_time=1 / Settings.speed,
+                run_time=1 / settings.speed,
             )
             if self.toFadeOut.get_height() >= self.camera.frame.get_height():
                 self.play(
                     self.camera.frame.animate.scale_to_fit_height(
                         self.toFadeOut.get_height() * 1.25
                     ),
-                    run_time=1 / Settings.speed,
+                    run_time=1 / settings.speed,
                 )
         else:
             self.camera.frame.scale_to_fit_width(self.toFadeOut.get_width() * 1.1)
@@ -444,7 +444,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
                 )
 
     def vsplit_frame(self):
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.scale_to_fit_height(
                     self.camera.frame.get_height() * 2
@@ -454,7 +454,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
             self.camera.frame.scale_to_fit_height(self.camera.frame.get_height() * 2)
 
         try:
-            if Settings.animate:
+            if settings.animate:
                 self.play(
                     self.toFadeOut.animate.align_to(self.camera.frame, m.UP).shift(
                         m.DOWN * 0.75
@@ -566,7 +566,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
             thirdColumnTitle,
         )
 
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 m.Create(horizontal),
                 m.Create(horizontal2),
@@ -659,19 +659,19 @@ class GitSimBaseCommand(m.MovingCameraScene):
             thirdColumnFilesDict[f] = text
 
         if len(firstColumnFiles):
-            if Settings.animate:
+            if settings.animate:
                 self.play(*[m.AddTextLetterByLetter(d) for d in firstColumnFiles])
             else:
                 self.add(*[d for d in firstColumnFiles])
 
         if len(secondColumnFiles):
-            if Settings.animate:
+            if settings.animate:
                 self.play(*[m.AddTextLetterByLetter(w) for w in secondColumnFiles])
             else:
                 self.add(*[w for w in secondColumnFiles])
 
         if len(thirdColumnFiles):
-            if Settings.animate:
+            if settings.animate:
                 self.play(*[m.AddTextLetterByLetter(s) for s in thirdColumnFiles])
             else:
                 self.add(*[s for s in thirdColumnFiles])
@@ -703,7 +703,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
                         0,
                     ),
                 )
-            if Settings.animate:
+            if settings.animate:
                 self.play(m.Create(firstColumnArrowMap[filename]))
             else:
                 self.add(firstColumnArrowMap[filename])
@@ -722,7 +722,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
                     0,
                 ),
             )
-            if Settings.animate:
+            if settings.animate:
                 self.play(m.Create(secondColumnArrowMap[filename]))
             else:
                 self.add(secondColumnArrowMap[filename])
@@ -756,7 +756,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
                 firstColumnFileNames.add(z)
 
     def center_frame_on_commit(self, commit):
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.move_to(
                     self.drawnCommits[commit.hexsha].get_center()
@@ -766,7 +766,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
             self.camera.frame.move_to(self.drawnCommits[commit.hexsha].get_center())
 
     def reset_head_branch(self, hexsha, shift=numpy.array([0.0, 0.0, 0.0])):
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.drawnRefs["HEAD"].animate.move_to(
                     (
@@ -800,7 +800,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
             )
 
     def translate_frame(self, shift):
-        if Settings.animate:
+        if settings.animate:
             self.play(self.camera.frame.animate.shift(shift))
         else:
             self.camera.frame.shift(shift)
@@ -817,7 +817,7 @@ class GitSimBaseCommand(m.MovingCameraScene):
         circle.height = 1
         circle.next_to(
             self.drawnCommits[child.hexsha],
-            m.LEFT if Settings.reverse else m.RIGHT,
+            m.LEFT if settings.reverse else m.RIGHT,
             buff=1.5,
         )
         circle.shift(shift)
@@ -844,13 +844,13 @@ class GitSimBaseCommand(m.MovingCameraScene):
         ).next_to(circle, m.DOWN)
         self.toFadeOut.add(message)
 
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.move_to(circle.get_center()),
                 m.Create(circle),
                 m.AddTextLetterByLetter(commitId),
                 m.AddTextLetterByLetter(message),
-                run_time=1 / Settings.speed,
+                run_time=1 / settings.speed,
             )
         else:
             self.camera.frame.move_to(circle.get_center())
@@ -860,8 +860,8 @@ class GitSimBaseCommand(m.MovingCameraScene):
         self.toFadeOut.add(circle)
 
         if draw_arrow:
-            if Settings.animate:
-                self.play(m.Create(arrow), run_time=1 / Settings.speed)
+            if settings.animate:
+                self.play(m.Create(arrow), run_time=1 / settings.speed)
             else:
                 self.add(arrow)
             self.toFadeOut.add(arrow)
@@ -901,8 +901,8 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
         ref = m.VGroup(refbox, refText)
 
-        if Settings.animate:
-            self.play(m.Create(ref), run_time=1 / Settings.speed)
+        if settings.animate:
+            self.play(m.Create(ref), run_time=1 / settings.speed)
         else:
             self.add(ref)
 
@@ -915,8 +915,8 @@ class GitSimBaseCommand(m.MovingCameraScene):
 
     def draw_dark_ref(self):
         refRec = m.Rectangle(
-            color=m.WHITE if Settings.light_mode else m.BLACK,
-            fill_color=m.WHITE if Settings.light_mode else m.BLACK,
+            color=m.WHITE if settings.light_mode else m.BLACK,
+            fill_color=m.WHITE if settings.light_mode else m.BLACK,
             height=0.4,
             width=1,
         )

--- a/git_sim/log.py
+++ b/git_sim/log.py
@@ -2,7 +2,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Log(GitSimBaseCommand):
@@ -16,7 +16,7 @@ class Log(GitSimBaseCommand):
             pass
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()}")
+        print(f"{settings.INFO_STRING} {type(self).__name__.lower()}")
         self.show_intro()
         self.get_commits()
         self.parse_commits(self.commits[0])
@@ -28,7 +28,7 @@ class Log(GitSimBaseCommand):
 
 def log(
     commits: int = typer.Option(
-        default=Settings.commits,
+        default=settings.commits,
         help="The number of commits to display in the simulated log output",
         min=1,
         max=12,

--- a/git_sim/merge.py
+++ b/git_sim/merge.py
@@ -8,7 +8,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Merge(GitSimBaseCommand):
@@ -38,7 +38,7 @@ class Merge(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()} {self.branch} {'--no-ff' if self.no_ff else ''}"
+            f"{settings.INFO_STRING } {type(self).__name__.lower()} {self.branch} {'--no-ff' if self.no_ff else ''}"
         )
 
         if self.repo.active_branch.name in self.repo.git.branch(

--- a/git_sim/rebase.py
+++ b/git_sim/rebase.py
@@ -7,7 +7,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Rebase(GitSimBaseCommand):
@@ -34,7 +34,7 @@ class Rebase(GitSimBaseCommand):
             pass
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()} {self.branch}")
+        print(f"{settings.INFO_STRING } {type(self).__name__.lower()} {self.branch}")
 
         if self.branch in self.repo.git.branch(
             "--contains", self.repo.active_branch.name
@@ -116,7 +116,7 @@ class Rebase(GitSimBaseCommand):
         circle.height = 1
         circle.next_to(
             self.drawnCommits[child],
-            m.LEFT if Settings.reverse else m.RIGHT,
+            m.LEFT if settings.reverse else m.RIGHT,
             buff=1.5,
         )
         circle.shift(shift)
@@ -155,13 +155,13 @@ class Rebase(GitSimBaseCommand):
         ).next_to(circle, m.DOWN)
         self.toFadeOut.add(message)
 
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.move_to(circle.get_center()),
                 m.Create(circle),
                 m.AddTextLetterByLetter(commitId),
                 m.AddTextLetterByLetter(message),
-                run_time=1 / Settings.speed,
+                run_time=1 / settings.speed,
             )
         else:
             self.camera.frame.move_to(circle.get_center())
@@ -171,8 +171,8 @@ class Rebase(GitSimBaseCommand):
         self.toFadeOut.add(circle)
 
         if draw_arrow:
-            if Settings.animate:
-                self.play(m.Create(arrow), run_time=1 / Settings.speed)
+            if settings.animate:
+                self.play(m.Create(arrow), run_time=1 / settings.speed)
             else:
                 self.add(arrow)
             self.toFadeOut.add(arrow)

--- a/git_sim/reset.py
+++ b/git_sim/reset.py
@@ -7,7 +7,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class ResetMode(Enum):
@@ -50,7 +50,7 @@ class Reset(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()}{' --' + self.mode.value if self.mode != ResetMode.DEFAULT else ''} {self.commit}",
+            f"{settings.INFO_STRING } {type(self).__name__.lower()}{' --' + self.mode.value if self.mode != ResetMode.DEFAULT else ''} {self.commit}",
         )
 
         self.show_intro()

--- a/git_sim/restore.py
+++ b/git_sim/restore.py
@@ -5,7 +5,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Restore(GitSimBaseCommand):
@@ -28,7 +28,7 @@ class Restore(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()} {' '.join(self.files)}"
+            f"{settings.INFO_STRING } {type(self).__name__.lower()} {' '.join(self.files)}"
         )
 
         self.show_intro()

--- a/git_sim/revert.py
+++ b/git_sim/revert.py
@@ -7,7 +7,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Revert(GitSimBaseCommand):
@@ -36,7 +36,7 @@ class Revert(GitSimBaseCommand):
             pass
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()} {self.commit}")
+        print(f"{settings.INFO_STRING } {type(self).__name__.lower()} {self.commit}")
 
         self.show_intro()
         self.get_commits()
@@ -94,7 +94,7 @@ class Revert(GitSimBaseCommand):
         circle.height = 1
         circle.next_to(
             self.drawnCommits[self.commits[0].hexsha],
-            m.LEFT if Settings.reverse else m.RIGHT,
+            m.LEFT if settings.reverse else m.RIGHT,
             buff=1.5,
         )
 
@@ -121,13 +121,13 @@ class Revert(GitSimBaseCommand):
         ).next_to(circle, m.DOWN)
         self.toFadeOut.add(message)
 
-        if Settings.animate:
+        if settings.animate:
             self.play(
                 self.camera.frame.animate.move_to(circle.get_center()),
                 m.Create(circle),
                 m.AddTextLetterByLetter(commitId),
                 m.AddTextLetterByLetter(message),
-                run_time=1 / Settings.speed,
+                run_time=1 / settings.speed,
             )
         else:
             self.camera.frame.move_to(circle.get_center())
@@ -136,8 +136,8 @@ class Revert(GitSimBaseCommand):
         self.drawnCommits["abcdef"] = circle
         self.toFadeOut.add(circle)
 
-        if Settings.animate:
-            self.play(m.Create(arrow), run_time=1 / Settings.speed)
+        if settings.animate:
+            self.play(m.Create(arrow), run_time=1 / settings.speed)
         else:
             self.add(arrow)
 

--- a/git_sim/settings.py
+++ b/git_sim/settings.py
@@ -1,6 +1,7 @@
 import pathlib
-from dataclasses import dataclass
 from enum import Enum
+
+from pydantic import BaseSettings
 
 
 class VideoFormat(str, Enum):
@@ -13,29 +14,32 @@ class ImgFormat(str, Enum):
     png = "png"
 
 
-@dataclass
-class Settings:
-    commits = 5
-    subcommand: str
-    show_intro = False
-    show_outro = False
+class Settings(BaseSettings):
+    allow_no_commits = False
     animate = False
-    title = "Git Sim, by initialcommit.com"
-    outro_top_text = "Thanks for using Initial Commit!"
-    outro_bottom_text = "Learn more at initialcommit.com"
-    speed = 1.5
+    auto_open = True
+    commits = 5
+    files: list[pathlib.Path] | None = None
+    hide_first_tag = False
+    img_format: ImgFormat = ImgFormat.jpg
+    INFO_STRING = "Simulating: git"
     light_mode = False
-    reverse = False
+    logo = pathlib.Path(__file__).parent.resolve() / "logo.png"
+    low_quality = False
     max_branches_per_commit = 1
     max_tags_per_commit = 1
-    hide_first_tag = False
-    allow_no_commits = False
-    low_quality = False
-    auto_open = True
-    INFO_STRING = "Simulating: git"
-    # os.path.join(str(pathlib.Path(__file__).parent.resolve()), "logo.png")
-    logo = pathlib.Path(__file__).parent.resolve() / "logo.png"
     media_dir = pathlib.Path().cwd()
-    files: list[pathlib.Path] | None = None
+    outro_bottom_text = "Learn more at initialcommit.com"
+    outro_top_text = "Thanks for using Initial Commit!"
+    reverse = False
+    show_intro = False
+    show_outro = False
+    speed = 1.5
+    title = "Git Sim, by initialcommit.com"
     video_format: VideoFormat = VideoFormat.mp4
-    img_format: ImgFormat = ImgFormat.jpg
+
+    class Config:
+        env_prefix = "git_sim"
+
+
+settings = Settings()

--- a/git_sim/stash.py
+++ b/git_sim/stash.py
@@ -5,7 +5,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Stash(GitSimBaseCommand):
@@ -34,7 +34,7 @@ class Stash(GitSimBaseCommand):
 
     def construct(self):
         print(
-            f"{Settings.INFO_STRING} {type(self).__name__.lower()} {' '.join(self.files) if not self.no_files else ''}"
+            f"{settings.INFO_STRING } {type(self).__name__.lower()} {' '.join(self.files) if not self.no_files else ''}"
         )
 
         self.show_intro()

--- a/git_sim/status.py
+++ b/git_sim/status.py
@@ -1,6 +1,6 @@
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Status(GitSimBaseCommand):
@@ -12,7 +12,7 @@ class Status(GitSimBaseCommand):
             pass
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()}")
+        print(f"{settings.INFO_STRING } {type(self).__name__.lower()}")
         self.show_intro()
         self.get_commits()
         self.parse_commits(self.commits[0])
@@ -25,8 +25,8 @@ class Status(GitSimBaseCommand):
 
 
 def status():
-    Settings.hide_first_tag = True
-    Settings.allow_no_commits = True
+    settings.hide_first_tag = True
+    settings.allow_no_commits = True
 
     scene = Status()
     handle_animations(scene=scene)

--- a/git_sim/tag.py
+++ b/git_sim/tag.py
@@ -3,7 +3,7 @@ import typer
 
 from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
-from git_sim.settings import Settings
+from git_sim.settings import settings
 
 
 class Tag(GitSimBaseCommand):
@@ -12,7 +12,7 @@ class Tag(GitSimBaseCommand):
         self.name = name
 
     def construct(self):
-        print(f"{Settings.INFO_STRING} {type(self).__name__.lower()} {self.name}")
+        print(f"{settings.INFO_STRING } {type(self).__name__.lower()} {self.name}")
 
         self.show_intro()
         self.get_commits()
@@ -39,8 +39,8 @@ class Tag(GitSimBaseCommand):
 
         fulltag = m.VGroup(tagRec, tagText)
 
-        if Settings.animate:
-            self.play(m.Create(fulltag), run_time=1 / Settings.speed)
+        if settings.animate:
+            self.play(m.Create(fulltag), run_time=1 / settings.speed)
         else:
             self.add(fulltag)
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
         "manim",
         "opencv-python-headless",
         "typer",
+        "pydantic",
     ],
     keywords="git sim simulation simulate git-simulate git-simulation git-sim manim animation gitanimation image video dryrun dry-run",
     project_urls={


### PR DESCRIPTION
Pydantic's BaseSettings give us automatic parsing of env vars for all defined settings for free.

Git-sim will use the default values specified in the `Settings` class if neither the corresponding flag nor env var is set.

If an env var is set, it will be used instead of the default.

If a flag is set, that will always be used, overriding an env var (if present).