### PR TITLE
Fix shorthands

### DIFF
--- a/git_sim/__main__.py
+++ b/git_sim/__main__.py
@@ -1,10 +1,4 @@
-import argparse
-import datetime
-import os
 import pathlib
-import subprocess
-import sys
-import time
 
 import typer
 
@@ -23,7 +17,7 @@ import git_sim.status
 import git_sim.tag
 from git_sim.settings import ImgFormat, VideoFormat, settings
 
-app = typer.Typer()
+app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 
 
 @app.callback(no_args_is_help=True)

--- a/git_sim/cherrypick.py
+++ b/git_sim/cherrypick.py
@@ -76,7 +76,9 @@ def cherry_pick(
         help="The ref (branch/tag), or commit ID to simulate cherry-pick onto active branch",
     ),
     edit: str = typer.Option(
-        default=None,
+        None,
+        "--edit",
+        "-e",
         help="Specify a new commit message for the cherry-picked commit",
     ),
 ):

--- a/git_sim/commit.py
+++ b/git_sim/commit.py
@@ -102,7 +102,9 @@ class Commit(GitSimBaseCommand):
 
 def commit(
     message: str = typer.Option(
-        default="New commit",
+        "New commit",
+        "--message",
+        "-m",
         help="The commit message of the new commit",
     ),
     amend: bool = typer.Option(


### PR DESCRIPTION
Fix short names for `cherry-pick --edit` (-e) and `commit --message` (-m) as discussed in #43 