### PR TITLE
add trailing underscore to env_prefix

### DIFF
--- a/git_sim/settings.py
+++ b/git_sim/settings.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     video_format: VideoFormat = VideoFormat.mp4
 
     class Config:
-        env_prefix = "git_sim"
+        env_prefix = "git_sim_"
 
 
 settings = Settings()


### PR DESCRIPTION
Fix a typo in the env_prefix variable of the Settings class.

Allows us to define env vars like `GIT_SIM_ANIMATE=true` (actually case-insensitive, so `git_sim_animate=ture` works just as well :smile:) to override the default settings.