### PR TITLE
Increase performance of typer autocompletion by breaking out subcommand functions into their own module

### DIFF
--- a/git_sim/__main__.py
+++ b/git_sim/__main__.py
@@ -6,28 +6,9 @@ import datetime
 import time
 import git
 
-import git_sim.add
-import git_sim.branch
-import git_sim.cherrypick
-import git_sim.commit
-import git_sim.log
-import git_sim.merge
-import git_sim.rebase
-import git_sim.reset
-import git_sim.restore
-import git_sim.revert
-import git_sim.stash
-import git_sim.status
-import git_sim.tag
-import git_sim.switch
-import git_sim.checkout
-import git_sim.fetch
-import git_sim.pull
-import git_sim.push
-import git_sim.clone
+import git_sim.commands
 
 from git_sim.settings import ImgFormat, VideoFormat, settings
-from manim import config, WHITE
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 
@@ -146,6 +127,8 @@ def main(
         help="Color commits by parameter, such as author",
     ),
 ):
+    from manim import config, WHITE
+
     settings.animate = animate
     settings.n = n
     settings.auto_open = auto_open
@@ -199,25 +182,25 @@ def main(
     config.output_file = "git-sim-" + ctx.invoked_subcommand + "_" + t + ".mp4"
 
 
-app.command()(git_sim.add.add)
-app.command()(git_sim.branch.branch)
-app.command()(git_sim.cherrypick.cherry_pick)
-app.command()(git_sim.commit.commit)
-app.command()(git_sim.log.log)
-app.command()(git_sim.merge.merge)
-app.command()(git_sim.rebase.rebase)
-app.command()(git_sim.reset.reset)
-app.command()(git_sim.restore.restore)
-app.command()(git_sim.revert.revert)
-app.command()(git_sim.stash.stash)
-app.command()(git_sim.status.status)
-app.command()(git_sim.tag.tag)
-app.command()(git_sim.switch.switch)
-app.command()(git_sim.checkout.checkout)
-app.command()(git_sim.fetch.fetch)
-app.command()(git_sim.pull.pull)
-app.command()(git_sim.push.push)
-app.command()(git_sim.clone.clone)
+app.command()(git_sim.commands.add)
+app.command()(git_sim.commands.branch)
+app.command()(git_sim.commands.checkout)
+app.command()(git_sim.commands.cherry_pick)
+app.command()(git_sim.commands.clone)
+app.command()(git_sim.commands.commit)
+app.command()(git_sim.commands.fetch)
+app.command()(git_sim.commands.log)
+app.command()(git_sim.commands.merge)
+app.command()(git_sim.commands.pull)
+app.command()(git_sim.commands.push)
+app.command()(git_sim.commands.rebase)
+app.command()(git_sim.commands.reset)
+app.command()(git_sim.commands.restore)
+app.command()(git_sim.commands.revert)
+app.command()(git_sim.commands.stash)
+app.command()(git_sim.commands.status)
+app.command()(git_sim.commands.switch)
+app.command()(git_sim.commands.tag)
 
 
 if __name__ == "__main__":

--- a/git_sim/__main__.py
+++ b/git_sim/__main__.py
@@ -4,7 +4,6 @@ import os
 import sys
 import datetime
 import time
-import git
 
 import git_sim.commands
 
@@ -127,6 +126,7 @@ def main(
         help="Color commits by parameter, such as author",
     ),
 ):
+    import git
     from manim import config, WHITE
 
     settings.animate = animate

--- a/git_sim/add.py
+++ b/git_sim/add.py
@@ -1,11 +1,9 @@
 import sys
 import git
 import manim as m
-import typer
 
 from typing import List
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -82,14 +80,3 @@ class Add(GitSimBaseCommand):
                         firstColumnArrowMap[z] = m.Arrow(
                             stroke_width=3, color=self.fontColor
                         )
-
-
-def add(
-    files: List[str] = typer.Argument(
-        default=None,
-        help="The names of one or more files to add to Git's staging area",
-    )
-):
-    settings.hide_first_tag = True
-    scene = Add(files=files)
-    handle_animations(scene=scene)

--- a/git_sim/branch.py
+++ b/git_sim/branch.py
@@ -1,7 +1,5 @@
 import manim as m
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -52,13 +50,3 @@ class Branch(GitSimBaseCommand):
         self.color_by()
         self.fadeout()
         self.show_outro()
-
-
-def branch(
-    name: str = typer.Argument(
-        ...,
-        help="The name of the new branch",
-    )
-):
-    scene = Branch(name=name)
-    handle_animations(scene=scene)

--- a/git_sim/checkout.py
+++ b/git_sim/checkout.py
@@ -4,9 +4,7 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -19,7 +17,11 @@ class Checkout(GitSimBaseCommand):
 
         if self.b:
             if self.branch in self.repo.heads:
-                print("git-sim error: can't create new branch '" + self.branch + "', it already exists")
+                print(
+                    "git-sim error: can't create new branch '"
+                    + self.branch
+                    + "', it already exists"
+                )
                 sys.exit(1)
         else:
             try:
@@ -75,7 +77,7 @@ class Checkout(GitSimBaseCommand):
             branch_commit = self.get_commit(self.branch)
 
             if self.is_ancestor:
-                commits_in_range = list(self.repo.iter_commits(self.branch + '..HEAD'))
+                commits_in_range = list(self.repo.iter_commits(self.branch + "..HEAD"))
 
                 # branch is reached from HEAD, so draw everything
                 if len(commits_in_range) <= self.n:
@@ -113,18 +115,3 @@ class Checkout(GitSimBaseCommand):
         self.color_by()
         self.fadeout()
         self.show_outro()
-
-
-def checkout(
-    branch: str = typer.Argument(
-        ...,
-        help="The name of the branch to checkout",
-    ),
-    b: bool = typer.Option(
-        False,
-        "-b",
-        help="Create the specified branch if it doesn't already exist",
-    ),
-):
-    scene = Checkout(branch=branch, b=b)
-    handle_animations(scene=scene)

--- a/git_sim/cherrypick.py
+++ b/git_sim/cherrypick.py
@@ -2,9 +2,7 @@ import sys
 
 import git
 import manim as m
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -70,19 +68,3 @@ class CherryPick(GitSimBaseCommand):
         self.color_by(offset=2)
         self.fadeout()
         self.show_outro()
-
-
-def cherry_pick(
-    commit: str = typer.Argument(
-        ...,
-        help="The ref (branch/tag), or commit ID to simulate cherry-pick onto active branch",
-    ),
-    edit: str = typer.Option(
-        None,
-        "--edit",
-        "-e",
-        help="Specify a new commit message for the cherry-picked commit",
-    ),
-):
-    scene = CherryPick(commit=commit, edit=edit)
-    handle_animations(scene=scene)

--- a/git_sim/clone.py
+++ b/git_sim/clone.py
@@ -5,13 +5,11 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 import tempfile
 import shutil
 import stat
 import re
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -28,12 +26,10 @@ class Clone(GitSimBaseCommand):
 
     def construct(self):
         if not settings.stdout and not settings.output_only_path and not settings.quiet:
-            print(
-                f"{settings.INFO_STRING } {type(self).__name__.lower()} {self.url}"
-            )
+            print(f"{settings.INFO_STRING } {type(self).__name__.lower()} {self.url}")
 
         self.show_intro()
-        
+
         # Configure paths to make local clone to run networked commands in
         repo_name = re.search(r"/([^/]+)/?$", self.url)
         if repo_name:
@@ -41,7 +37,9 @@ class Clone(GitSimBaseCommand):
             if repo_name.endswith(".git"):
                 repo_name = repo_name[:-4]
         else:
-            print(f"git-sim error: Invalid repo URL, please confirm repo URL and try again")
+            print(
+                f"git-sim error: Invalid repo URL, please confirm repo URL and try again"
+            )
             sys.exit(1)
         new_dir = os.path.join(tempfile.gettempdir(), "git_sim", repo_name)
 
@@ -49,7 +47,9 @@ class Clone(GitSimBaseCommand):
         try:
             self.repo = git.Repo.clone_from(self.url, new_dir, no_hardlinks=True)
         except git.GitCommandError as e:
-            print(f"git-sim error: Invalid repo URL, please confirm repo URL and try again")
+            print(
+                f"git-sim error: Invalid repo URL, please confirm repo URL and try again"
+            )
             sys.exit(1)
 
         head_commit = self.get_commit()
@@ -69,7 +69,7 @@ class Clone(GitSimBaseCommand):
 
     def add_details(self, repo_name):
         text1 = m.Text(
-            f"Successfully cloned from {self.url} into ./{repo_name}", 
+            f"Successfully cloned from {self.url} into ./{repo_name}",
             font="Monospace",
             font_size=20,
             color=self.fontColor,
@@ -100,12 +100,3 @@ class Clone(GitSimBaseCommand):
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
-
-def clone(
-    url: str = typer.Argument(
-        ...,
-        help="The web URL or filesystem path of the Git repo to clone",
-    ),
-):
-    scene = Clone(url=url)
-    handle_animations(scene=scene)

--- a/git_sim/commands.py
+++ b/git_sim/commands.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import typer
+
+from typing import List, TYPE_CHECKING
+
+from git_sim.enums import ResetMode, StashSubCommand
+from git_sim.settings import settings
+
+if TYPE_CHECKING:
+    from manim import Scene
+
+
+def handle_animations(scene: Scene) -> None:
+    from git_sim.animations import handle_animations as _handle_animations
+
+    return _handle_animations(scene)
+
+
+def add(
+    files: List[str] = typer.Argument(
+        default=None,
+        help="The names of one or more files to add to Git's staging area",
+    )
+):
+    from git_sim.add import Add
+
+    settings.hide_first_tag = True
+    scene = Add(files=files)
+    handle_animations(scene=scene)
+
+
+def branch(
+    name: str = typer.Argument(
+        ...,
+        help="The name of the new branch",
+    )
+):
+    from git_sim.branch import Branch
+
+    scene = Branch(name=name)
+    handle_animations(scene=scene)
+
+
+def checkout(
+    branch: str = typer.Argument(
+        ...,
+        help="The name of the branch to checkout",
+    ),
+    b: bool = typer.Option(
+        False,
+        "-b",
+        help="Create the specified branch if it doesn't already exist",
+    ),
+):
+    from git_sim.checkout import Checkout
+
+    scene = Checkout(branch=branch, b=b)
+    handle_animations(scene=scene)
+
+
+def cherry_pick(
+    commit: str = typer.Argument(
+        ...,
+        help="The ref (branch/tag), or commit ID to simulate cherry-pick onto active branch",
+    ),
+    edit: str = typer.Option(
+        None,
+        "--edit",
+        "-e",
+        help="Specify a new commit message for the cherry-picked commit",
+    ),
+):
+    from git_sim.cherrypick import CherryPick
+
+    scene = CherryPick(commit=commit, edit=edit)
+    handle_animations(scene=scene)
+
+
+def clone(
+    url: str = typer.Argument(
+        ...,
+        help="The web URL or filesystem path of the Git repo to clone",
+    ),
+):
+    from git_sim.clone import Clone
+
+    scene = Clone(url=url)
+    handle_animations(scene=scene)
+
+
+def commit(
+    message: str = typer.Option(
+        "New commit",
+        "--message",
+        "-m",
+        help="The commit message of the new commit",
+    ),
+    amend: bool = typer.Option(
+        default=False,
+        help="Amend the last commit message, must be used with the --message flag",
+    ),
+):
+    from git_sim.commit import Commit
+
+    settings.hide_first_tag = True
+    scene = Commit(message=message, amend=amend)
+    handle_animations(scene=scene)
+
+
+def fetch(
+    remote: str = typer.Argument(
+        ...,
+        help="The name of the remote to fetch from",
+    ),
+    branch: str = typer.Argument(
+        ...,
+        help="The name of the branch to fetch",
+    ),
+):
+    from git_sim.fetch import Fetch
+
+    scene = Fetch(remote=remote, branch=branch)
+    handle_animations(scene=scene)
+
+
+def log(
+    ctx: typer.Context,
+    n: int = typer.Option(
+        None,
+        "-n",
+        help="Number of commits to display from branch heads",
+    ),
+    all: bool = typer.Option(
+        False,
+        "--all",
+        help="Display all local branches in the log output",
+    ),
+):
+    from git_sim.log import Log
+
+    scene = Log(ctx=ctx, n=n, all=all)
+    handle_animations(scene=scene)
+
+
+def merge(
+    branch: str = typer.Argument(
+        ...,
+        help="The name of the branch to merge into the active checked-out branch",
+    ),
+    no_ff: bool = typer.Option(
+        False,
+        "--no-ff",
+        help="Simulate creation of a merge commit in all cases, even when the merge could instead be resolved as a fast-forward",
+    ),
+):
+    from git_sim.merge import Merge
+
+    scene = Merge(branch=branch, no_ff=no_ff)
+    handle_animations(scene=scene)
+
+
+def pull(
+    remote: str = typer.Argument(
+        default=None,
+        help="The name of the remote to pull from",
+    ),
+    branch: str = typer.Argument(
+        default=None,
+        help="The name of the branch to pull",
+    ),
+):
+    from git_sim.pull import Pull
+
+    scene = Pull(remote=remote, branch=branch)
+    handle_animations(scene=scene)
+
+
+def push(
+    remote: str = typer.Argument(
+        default=None,
+        help="The name of the remote to push to",
+    ),
+    branch: str = typer.Argument(
+        default=None,
+        help="The name of the branch to push",
+    ),
+):
+    from git_sim.push import Push
+
+    scene = Push(remote=remote, branch=branch)
+    handle_animations(scene=scene)
+
+
+def rebase(
+    branch: str = typer.Argument(
+        ...,
+        help="The branch to simulate rebasing the checked-out commit onto",
+    )
+):
+    from git_sim.rebase import Rebase
+
+    scene = Rebase(branch=branch)
+    handle_animations(scene=scene)
+
+
+def reset(
+    commit: str = typer.Argument(
+        default="HEAD",
+        help="The ref (branch/tag), or commit ID to simulate reset to",
+    ),
+    mode: ResetMode = typer.Option(
+        default="mixed",
+        help="Either mixed, soft, or hard",
+    ),
+    soft: bool = typer.Option(
+        default=False,
+        help="Simulate a soft reset, shortcut for --mode=soft",
+    ),
+    mixed: bool = typer.Option(
+        default=False,
+        help="Simulate a mixed reset, shortcut for --mode=mixed",
+    ),
+    hard: bool = typer.Option(
+        default=False,
+        help="Simulate a soft reset, shortcut for --mode=hard",
+    ),
+):
+    from git_sim.reset import Reset
+
+    settings.hide_first_tag = True
+    scene = Reset(commit=commit, mode=mode, soft=soft, mixed=mixed, hard=hard)
+    handle_animations(scene=scene)
+
+
+def restore(
+    files: List[str] = typer.Argument(
+        default=None,
+        help="The names of one or more files to restore",
+    )
+):
+    from git_sim.restore import Restore
+
+    settings.hide_first_tag = True
+    scene = Restore(files=files)
+    handle_animations(scene=scene)
+
+
+def revert(
+    commit: str = typer.Argument(
+        default="HEAD",
+        help="The ref (branch/tag), or commit ID to simulate revert",
+    )
+):
+    from git_sim.revert import Revert
+
+    settings.hide_first_tag = True
+    scene = Revert(commit=commit)
+    handle_animations(scene=scene)
+
+
+def stash(
+    command: StashSubCommand = typer.Argument(
+        default=None,
+        help="Stash subcommand (push, pop, apply)",
+    ),
+    files: List[str] = typer.Argument(
+        default=None,
+        help="The name of the file to stash changes for",
+    ),
+):
+    from git_sim.stash import Stash
+
+    settings.hide_first_tag = True
+    scene = Stash(files=files, command=command)
+    handle_animations(scene=scene)
+
+
+def status():
+    from git_sim.status import Status
+
+    settings.hide_first_tag = True
+    settings.allow_no_commits = True
+
+    scene = Status()
+    handle_animations(scene=scene)
+
+
+def switch(
+    branch: str = typer.Argument(
+        ...,
+        help="The name of the branch to switch to",
+    ),
+    c: bool = typer.Option(
+        False,
+        "-c",
+        help="Create the specified branch if it doesn't already exist",
+    ),
+):
+    from git_sim.switch import Switch
+
+    scene = Switch(branch=branch, c=c)
+    handle_animations(scene=scene)
+
+
+def tag(
+    name: str = typer.Argument(
+        ...,
+        help="The name of the new tag",
+    )
+):
+    from git_sim.tag import Tag
+
+    scene = Tag(name=name)
+    handle_animations(scene=scene)

--- a/git_sim/commit.py
+++ b/git_sim/commit.py
@@ -2,9 +2,7 @@ import sys
 
 import git
 import manim as m
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -102,20 +100,3 @@ class Commit(GitSimBaseCommand):
                 secondColumnArrowMap[y.a_path] = m.Arrow(
                     stroke_width=3, color=self.fontColor
                 )
-
-
-def commit(
-    message: str = typer.Option(
-        "New commit",
-        "--message",
-        "-m",
-        help="The commit message of the new commit",
-    ),
-    amend: bool = typer.Option(
-        default=False,
-        help="Amend the last commit message, must be used with the --message flag",
-    ),
-):
-    settings.hide_first_tag = True
-    scene = Commit(message=message, amend=amend)
-    handle_animations(scene=scene)

--- a/git_sim/enums.py
+++ b/git_sim/enums.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class ResetMode(Enum):
+    DEFAULT = "mixed"
+    SOFT = "soft"
+    MIXED = "mixed"
+    HARD = "hard"
+
+
+class StashSubCommand(Enum):
+    POP = "pop"
+    APPLY = "apply"
+    PUSH = "push"

--- a/git_sim/fetch.py
+++ b/git_sim/fetch.py
@@ -5,12 +5,10 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 import tempfile
 import shutil
 import stat
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -76,19 +74,7 @@ class Fetch(GitSimBaseCommand):
         self.repo.git.clear_cache()
         shutil.rmtree(new_dir, onerror=del_rw)
 
+
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
-
-def fetch(
-    remote: str = typer.Argument(
-        ...,
-        help="The name of the remote to fetch from",
-    ),
-    branch: str = typer.Argument(
-        ...,
-        help="The name of the branch to fetch",
-    ),
-):
-    scene = Fetch(remote=remote, branch=branch)
-    handle_animations(scene=scene)

--- a/git_sim/log.py
+++ b/git_sim/log.py
@@ -1,6 +1,5 @@
 import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 import numpy
@@ -46,20 +45,3 @@ class Log(GitSimBaseCommand):
         self.color_by()
         self.fadeout()
         self.show_outro()
-
-
-def log(
-    ctx: typer.Context,
-    n: int = typer.Option(
-        None,
-        "-n",
-        help="Number of commits to display from branch heads",
-    ),
-    all: bool = typer.Option(
-        False,
-        "--all",
-        help="Display all local branches in the log output",
-    ),
-):
-    scene = Log(ctx=ctx, n=n, all=all)
-    handle_animations(scene=scene)

--- a/git_sim/merge.py
+++ b/git_sim/merge.py
@@ -4,9 +4,7 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -119,18 +117,3 @@ class Merge(GitSimBaseCommand):
 
         self.fadeout()
         self.show_outro()
-
-
-def merge(
-    branch: str = typer.Argument(
-        ...,
-        help="The name of the branch to merge into the active checked-out branch",
-    ),
-    no_ff: bool = typer.Option(
-        False,
-        "--no-ff",
-        help="Simulate creation of a merge commit in all cases, even when the merge could instead be resolved as a fast-forward",
-    ),
-):
-    scene = Merge(branch=branch, no_ff=no_ff)
-    handle_animations(scene=scene)

--- a/git_sim/pull.py
+++ b/git_sim/pull.py
@@ -5,13 +5,11 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 import tempfile
 import shutil
 import stat
 import re
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -34,7 +32,7 @@ class Pull(GitSimBaseCommand):
             )
 
         self.show_intro()
-        
+
         # Configure paths to make local clone to run networked commands in
         git_root = self.repo.git.rev_parse("--show-toplevel")
         repo_name = os.path.basename(self.repo.working_dir)
@@ -62,7 +60,7 @@ class Pull(GitSimBaseCommand):
         except git.GitCommandError as e:
             if "CONFLICT" in e.stdout:
                 # Restrict to default number of commits since we'll show the table/zones
-                self.n = self.n_default 
+                self.n = self.n_default
 
                 # Get list of conflicted filenames
                 self.conflicted_files = re.findall(r"Merge conflict in (.+)", e.stdout)
@@ -80,7 +78,9 @@ class Pull(GitSimBaseCommand):
                     third_column_name="----",
                 )
             else:
-                print(f"git-sim error: git pull failed for unhandled reason: {e.stdout}")
+                print(
+                    f"git-sim error: git pull failed for unhandled reason: {e.stdout}"
+                )
                 self.repo.git.clear_cache()
                 shutil.rmtree(new_dir, onerror=del_rw)
                 sys.exit(1)
@@ -108,19 +108,7 @@ class Pull(GitSimBaseCommand):
         for filename in self.conflicted_files:
             secondColumnFileNames.add(filename)
 
+
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
-
-def pull(
-    remote: str = typer.Argument(
-        default=None,
-        help="The name of the remote to pull from",
-    ),
-    branch: str = typer.Argument(
-        default=None,
-        help="The name of the branch to pull",
-    ),
-):
-    scene = Pull(remote=remote, branch=branch)
-    handle_animations(scene=scene)

--- a/git_sim/push.py
+++ b/git_sim/push.py
@@ -5,13 +5,11 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 import tempfile
 import shutil
 import stat
 import re
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -34,7 +32,7 @@ class Push(GitSimBaseCommand):
             )
 
         self.show_intro()
-        
+
         # Configure paths to make local clone to run networked commands in
         git_root = self.repo.git.rev_parse("--show-toplevel")
         repo_name = os.path.basename(self.repo.working_dir)
@@ -55,7 +53,9 @@ class Push(GitSimBaseCommand):
             remote_url = orig_remotes[0].url
 
         # Create local clone of remote repo to simulate push to so we don't touch the real remote
-        self.remote_repo = git.Repo.clone_from(remote_url, new_dir2, no_hardlinks=True, bare=True)
+        self.remote_repo = git.Repo.clone_from(
+            remote_url, new_dir2, no_hardlinks=True, bare=True
+        )
 
         # Reset local clone remote to the local clone of remote repo
         if self.remote:
@@ -88,7 +88,12 @@ class Push(GitSimBaseCommand):
 
         head_commit = self.get_commit()
         if push_result > 0:
-            self.parse_commits(head_commit, make_branches_remote=(self.remote if self.remote else self.repo.remotes[0].name))
+            self.parse_commits(
+                head_commit,
+                make_branches_remote=(
+                    self.remote if self.remote else self.repo.remotes[0].name
+                ),
+            )
         else:
             self.parse_commits(head_commit)
         self.recenter_frame()
@@ -193,20 +198,6 @@ class Push(GitSimBaseCommand):
             self.add(*texts)
 
 
-
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
-
-def push(
-    remote: str = typer.Argument(
-        default=None,
-        help="The name of the remote to push to",
-    ),
-    branch: str = typer.Argument(
-        default=None,
-        help="The name of the branch to push",
-    ),
-):
-    scene = Push(remote=remote, branch=branch)
-    handle_animations(scene=scene)

--- a/git_sim/rebase.py
+++ b/git_sim/rebase.py
@@ -3,9 +3,7 @@ import sys
 import git
 import manim as m
 import numpy
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -179,13 +177,3 @@ class Rebase(GitSimBaseCommand):
             self.toFadeOut.add(arrow)
 
         return sha
-
-
-def rebase(
-    branch: str = typer.Argument(
-        ...,
-        help="The branch to simulate rebasing the checked-out commit onto",
-    )
-):
-    scene = Rebase(branch=branch)
-    handle_animations(scene=scene)

--- a/git_sim/reset.py
+++ b/git_sim/reset.py
@@ -3,18 +3,10 @@ from enum import Enum
 
 import git
 import manim as m
-import typer
 
-from git_sim.animations import handle_animations
+from git_sim.enums import ResetMode
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
-
-
-class ResetMode(Enum):
-    DEFAULT = "mixed"
-    SOFT = "soft"
-    MIXED = "mixed"
-    HARD = "hard"
 
 
 class Reset(GitSimBaseCommand):
@@ -145,30 +137,3 @@ class Reset(GitSimBaseCommand):
                     secondColumnFileNames.add(y.a_path)
                 elif self.mode == ResetMode.HARD:
                     firstColumnFileNames.add(y.a_path)
-
-
-def reset(
-    commit: str = typer.Argument(
-        default="HEAD",
-        help="The ref (branch/tag), or commit ID to simulate reset to",
-    ),
-    mode: ResetMode = typer.Option(
-        default=ResetMode.MIXED.value,
-        help="Either mixed, soft, or hard",
-    ),
-    soft: bool = typer.Option(
-        default=False,
-        help="Simulate a soft reset, shortcut for --mode=soft",
-    ),
-    mixed: bool = typer.Option(
-        default=False,
-        help="Simulate a mixed reset, shortcut for --mode=mixed",
-    ),
-    hard: bool = typer.Option(
-        default=False,
-        help="Simulate a soft reset, shortcut for --mode=hard",
-    ),
-):
-    settings.hide_first_tag = True
-    scene = Reset(commit=commit, mode=mode, soft=soft, mixed=mixed, hard=hard)
-    handle_animations(scene=scene)

--- a/git_sim/restore.py
+++ b/git_sim/restore.py
@@ -1,10 +1,8 @@
 import sys
 import manim as m
-import typer
 
 from typing import List
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -71,14 +69,3 @@ class Restore(GitSimBaseCommand):
                         firstColumnArrowMap[y.a_path] = m.Arrow(
                             stroke_width=3, color=self.fontColor
                         )
-
-
-def restore(
-    files: List[str] = typer.Argument(
-        default=None,
-        help="The names of one or more files to restore",
-    )
-):
-    settings.hide_first_tag = True
-    scene = Restore(files=files)
-    handle_animations(scene=scene)

--- a/git_sim/revert.py
+++ b/git_sim/revert.py
@@ -3,9 +3,7 @@ import sys
 import git
 import manim as m
 import numpy
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -157,14 +155,3 @@ class Revert(GitSimBaseCommand):
     ):
         for filename in self.revert.stats.files:
             secondColumnFileNames.add(filename)
-
-
-def revert(
-    commit: str = typer.Argument(
-        default="HEAD",
-        help="The ref (branch/tag), or commit ID to simulate revert",
-    )
-):
-    settings.hide_first_tag = True
-    scene = Revert(commit=commit)
-    handle_animations(scene=scene)

--- a/git_sim/stash.py
+++ b/git_sim/stash.py
@@ -1,19 +1,12 @@
 import sys
 from enum import Enum
 import manim as m
-import typer
 
 from typing import List
 
-from git_sim.animations import handle_animations
+from git_sim.enums import StashSubCommand
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
-
-
-class StashSubCommand(Enum):
-    POP = "pop"
-    APPLY = "apply"
-    PUSH = "push"
 
 
 class Stash(GitSimBaseCommand):
@@ -186,18 +179,3 @@ class Stash(GitSimBaseCommand):
                         secondColumnArrowMap[y.a_path] = m.Arrow(
                             stroke_width=3, color=self.fontColor
                         )
-
-
-def stash(
-    command: StashSubCommand = typer.Argument(
-        default=None,
-        help="Stash subcommand (push, pop, apply)",
-    ),
-    files: List[str] = typer.Argument(
-        default=None,
-        help="The name of the file to stash changes for",
-    ),
-):
-    settings.hide_first_tag = True
-    scene = Stash(files=files, command=command)
-    handle_animations(scene=scene)

--- a/git_sim/status.py
+++ b/git_sim/status.py
@@ -1,4 +1,3 @@
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -24,11 +23,3 @@ class Status(GitSimBaseCommand):
         self.setup_and_draw_zones()
         self.fadeout()
         self.show_outro()
-
-
-def status():
-    settings.hide_first_tag = True
-    settings.allow_no_commits = True
-
-    scene = Status()
-    handle_animations(scene=scene)

--- a/git_sim/switch.py
+++ b/git_sim/switch.py
@@ -4,9 +4,7 @@ from argparse import Namespace
 import git
 import manim as m
 import numpy
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -19,7 +17,11 @@ class Switch(GitSimBaseCommand):
 
         if self.c:
             if self.branch in self.repo.heads:
-                print("git-sim error: can't create new branch '" + self.branch + "', it already exists")
+                print(
+                    "git-sim error: can't create new branch '"
+                    + self.branch
+                    + "', it already exists"
+                )
                 sys.exit(1)
         else:
             try:
@@ -75,7 +77,7 @@ class Switch(GitSimBaseCommand):
             branch_commit = self.get_commit(self.branch)
 
             if self.is_ancestor:
-                commits_in_range = list(self.repo.iter_commits(self.branch + '..HEAD'))
+                commits_in_range = list(self.repo.iter_commits(self.branch + "..HEAD"))
 
                 # branch is reached from HEAD, so draw everything
                 if len(commits_in_range) <= self.n:
@@ -113,18 +115,3 @@ class Switch(GitSimBaseCommand):
         self.color_by()
         self.fadeout()
         self.show_outro()
-
-
-def switch(
-    branch: str = typer.Argument(
-        ...,
-        help="The name of the branch to switch to",
-    ),
-    c: bool = typer.Option(
-        False,
-        "-c",
-        help="Create the specified branch if it doesn't already exist",
-    ),
-):
-    scene = Switch(branch=branch, c=c)
-    handle_animations(scene=scene)

--- a/git_sim/tag.py
+++ b/git_sim/tag.py
@@ -1,7 +1,5 @@
 import manim as m
-import typer
 
-from git_sim.animations import handle_animations
 from git_sim.git_sim_base_command import GitSimBaseCommand
 from git_sim.settings import settings
 
@@ -52,13 +50,3 @@ class Tag(GitSimBaseCommand):
         self.color_by()
         self.fadeout()
         self.show_outro()
-
-
-def tag(
-    name: str = typer.Argument(
-        ...,
-        help="The name of the new tag",
-    )
-):
-    scene = Tag(name=name)
-    handle_animations(scene=scene)


### PR DESCRIPTION
Fixes #76

The main problem seemed to be loading `manim`. By separating the commands from the modules where `manim` needs to be loaded, it is possible to delay loading it until a command is actually executed, since the auto-completion only relied on those command functions being registered by `typer`.

While the auto-completion is still a bit slow, it is a significant improvement (3x), and as a bonus because `manim` isn't loaded the `Manim Community v0.16.0.post0` log doesn't clutter the output of `git-sim --show-completion SHELL`.

### Previous:

https://user-images.githubusercontent.com/24759037/227437226-8cc733ff-6c98-423c-ba9b-7d49e3074011.mp4

### With PR:

https://user-images.githubusercontent.com/24759037/227437053-cd4edcb7-62cb-4fcd-980a-30a6b129dc50.mp4