### PR TITLE
clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM python:3
+FROM python:3.10-bullseye
+
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get -y install --no-install-recommends \
+        build-essential \
+        ffmpeg \
+        libcairo2-dev \
+        libpango1.0-dev
+
+COPY setup.py README.md MANIFEST.in /app/
+
+COPY git_sim /app/git_sim
+
+RUN pip install /app
 
 WORKDIR /usr/src/git-sim
-
-RUN apt update
-
-RUN apt -y install build-essential python3-dev libcairo2-dev libpango1.0-dev ffmpeg
-
-RUN pip3 install manim
-
-RUN pip3 install git-sim
 
 ENTRYPOINT [ "git-sim" ]


### PR DESCRIPTION
I saw that the Dockerfile installs git-sim from pip (`RUN pip3 install git-sim`), I think it makes more sense to copy the code and install it directly - hence this PR :)

While at it, I also removed some packages that are not required (`python3-dev`, and setting `--no-install-recommends`).

The syntax for calling git-sim in Docker does not change (-> no changes to README.md).